### PR TITLE
handle links to const sets in TableVariation

### DIFF
--- a/docs/robbdd.md
+++ b/docs/robbdd.md
@@ -103,8 +103,6 @@ For example, `(ns=tutorial) pickplace-tmpl` will be transformed into a node with
 which has the short form `tutorial:pickplace-tmpl`.
 IRIs allow extending a model in the generated graph with any additional information as needed,
 as long as they refer the model's IRI.
-In RobBDD, the element IDs, e.g., `evt-scr-start`, are combined with a namespace declaration,
-e.g., `ns tutorial`, to generate the full IRI in the graph.
 The namespace reference can either be explicit like with task or event declarations, or inherited from
 the parent like with variable declarations.
 

--- a/examples/generate_bdd_specs.py
+++ b/examples/generate_bdd_specs.py
@@ -31,11 +31,11 @@ MODEL_URLS = {
 }
 PP_MODELS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/pickplace.tmpl.json": "json-ld",
-    f"{URL_SECORO_M}/acceptance-criteria/bdd/pickplace-secorolab-isaac.var.json": "json-ld",
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/pickplace-secorolab-isaac.var.json": "json-ld",
 }
 SORT_MODELS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/sorting.tmpl.json": "json-ld",
-    f"{URL_SECORO_M}/acceptance-criteria/bdd/sorting-secorolab-isaac.var.json": "json-ld",
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/sorting-secorolab-isaac.var.json": "json-ld",
 }
 
 

--- a/examples/generated/environment.py
+++ b/examples/generated/environment.py
@@ -18,9 +18,9 @@ MODELS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/simulation/secorolab-isaac.sim.json": "json-ld",
     f"{URL_SECORO_M}/acceptance-criteria/bdd/scenes/secorolab-env.scene.json": "json-ld",
     #    f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/pickplace.tmpl.json": "json-ld",
-    #    f"{URL_SECORO_M}/acceptance-criteria/bdd/pickplace-secorolab-isaac.var.json": "json-ld",
+    #    f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/pickplace-secorolab-isaac.var.json": "json-ld",
     f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/sorting.tmpl.json": "json-ld",
-    f"{URL_SECORO_M}/acceptance-criteria/bdd/sorting-secorolab-isaac.var.json": "json-ld",
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/sorting-secorolab-isaac.var.json": "json-ld",
     f"{URL_SECORO_M}/acceptance-criteria/bdd/execution/pickplace-secorolab-isaac.exec.json": "json-ld",
     f"{URL_SECORO_M}/acceptance-criteria/bdd/execution/pickplace-secorolab-mockup.bhv.exec.json": "json-ld",
 }

--- a/src/bdd_dsl/models/variation.py
+++ b/src/bdd_dsl/models/variation.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from typing import Any, Iterable, Iterator
+from typing import Any, Iterable, Iterator, Optional
 import itertools
 from rdflib import BNode, Graph, URIRef, Literal
 from rdf_utils.collection import load_list_re
@@ -24,6 +24,17 @@ URI_BDD_PRED_REP_ALLOWED = NS_MM_BDD["repetition-allowed"]
 URI_BDD_PRED_LENGTH = NS_MM_BDD["length"]
 
 
+def try_get_const_set_elems(graph: Graph, set_id: URIRef) -> Optional[list]:
+    sets_data_types = get_node_types(graph=graph, node_id=set_id)
+    if URI_BDD_TYPE_CONST_SET not in sets_data_types:
+        return None
+
+    elem_list = []
+    for elem in graph.objects(subject=set_id, predicate=URI_BDD_PRED_ELEMS):
+        elem_list.append(elem)
+    return elem_list
+
+
 class SetEnumerationModel(ModelBase):
     """Model for handling simple enumeration of a set, namely combinations and permutations."""
 
@@ -44,25 +55,25 @@ class SetEnumerationModel(ModelBase):
         if rep_allowed_node is None:
             rep_allowed = False
         else:
-            assert isinstance(
-                rep_allowed_node, Literal
-            ), f"SetEnumeration: '{self.id}' does not have literal 'repetition-allowed' property: {rep_allowed_node}"
+            assert isinstance(rep_allowed_node, Literal), (
+                f"SetEnumeration: '{self.id}' does not have literal 'repetition-allowed' property: {rep_allowed_node}"
+            )
             rep_allowed = rep_allowed_node.toPython()
-            assert isinstance(
-                rep_allowed, bool
-            ), f"SetEnumeration: '{self.id}' does not have boolean 'repetition-allowed': {rep_allowed_node}"
+            assert isinstance(rep_allowed, bool), (
+                f"SetEnumeration: '{self.id}' does not have boolean 'repetition-allowed': {rep_allowed_node}"
+            )
         self.set_attr(key=URI_BDD_PRED_REP_ALLOWED, val=rep_allowed)
 
         # set to enumerate
         from_node = graph.value(subject=self.id, predicate=URI_BDD_PRED_FROM)
-        assert isinstance(
-            from_node, URIRef
-        ), f"SetEnumeration: '{self.id}' does not link to URIRef via a 'from' property"
+        assert isinstance(from_node, URIRef), (
+            f"SetEnumeration: '{self.id}' does not link to URIRef via a 'from' property"
+        )
 
         set_model = ModelBase(node_id=from_node, graph=graph)
-        assert (
-            URI_BDD_TYPE_CONST_SET in set_model.types
-        ), f"type(s) not handled for Set {set_model.id}: {set_model.types}"
+        assert URI_BDD_TYPE_CONST_SET in set_model.types, (
+            f"type(s) not handled for Set {set_model.id}: {set_model.types}"
+        )
         from_list = []
         for elem in graph.objects(subject=set_model.id, predicate=URI_BDD_PRED_ELEMS):
             from_list.append(elem)
@@ -73,17 +84,17 @@ class SetEnumerationModel(ModelBase):
         if length_node is None:
             length = len(from_list)
         else:
-            assert isinstance(
-                length_node, Literal
-            ), f"SetEnumeration: '{self.id}' does not have int literal 'from' property: {length_node}"
+            assert isinstance(length_node, Literal), (
+                f"SetEnumeration: '{self.id}' does not have int literal 'from' property: {length_node}"
+            )
             length = length_node.toPython()
-            assert (
-                isinstance(length, int) and length > 0
-            ), f"SetEnumeration: '{self.id}': 'length' property is not a positive integer: {length}"
+            assert isinstance(length, int) and length > 0, (
+                f"SetEnumeration: '{self.id}': 'length' property is not a positive integer: {length}"
+            )
 
-        assert length <= len(
-            from_list
-        ), f"SetEnumeration '{self.id}': 'length'(={length}) > set size(={len(from_list)})"
+        assert length <= len(from_list), (
+            f"SetEnumeration '{self.id}': 'length'(={length}) > set size(={len(from_list)})"
+        )
         self.set_attr(key=URI_BDD_PRED_LENGTH, val=length)
 
     def enumerate(self) -> Iterator:
@@ -130,38 +141,34 @@ class TaskVariationModel(ModelBase):
             var_list = self._get_variable_list(graph=full_graph)
 
             of_sets_list_node = full_graph.value(subject=self.id, predicate=URI_BDD_PRED_OF_SETS)
-            assert isinstance(
-                of_sets_list_node, BNode
-            ), f"CartesianProductVariation '{self.id}' does not have a valid 'of-sets' property: {of_sets_list_node}"
+            assert isinstance(of_sets_list_node, BNode), (
+                f"CartesianProductVariation '{self.id}' does not have a valid 'of-sets' property: {of_sets_list_node}"
+            )
 
             sets_list = load_list_re(
                 graph=full_graph, first_node=of_sets_list_node, parse_uri=True, quiet=True
             )
 
-            assert (
-                len(sets_list) == len(var_list)
-            ), f"Cart Product '{self.id}': length mismatch 'variable-list' (len={len(var_list)}) != 'of-sets' (len={len(sets_list)})"
+            assert len(sets_list) == len(var_list), (
+                f"Cart Product '{self.id}': length mismatch 'variable-list' (len={len(var_list)}) != 'of-sets' (len={len(sets_list)})"
+            )
 
             for sets_data in sets_list:
                 if isinstance(sets_data, list):
                     continue
 
-                assert isinstance(
-                    sets_data, URIRef
-                ), f"TaskVariation '{self.id}': unexpected sets type for: {sets_data}"
+                assert isinstance(sets_data, URIRef), (
+                    f"TaskVariation '{self.id}': unexpected sets type for: {sets_data}"
+                )
 
                 # if set URI already processed
                 if sets_data in self.const_sets or sets_data in self.set_enums:
                     continue
 
-                sets_data_types = get_node_types(graph=full_graph, node_id=sets_data)
-
                 # constant sets
-                if URI_BDD_TYPE_CONST_SET in sets_data_types:
-                    sd_list = []
-                    for elem in full_graph.objects(subject=sets_data, predicate=URI_BDD_PRED_ELEMS):
-                        sd_list.append(elem)
-                    self.const_sets[sets_data] = sd_list
+                elem_list = try_get_const_set_elems(graph=full_graph, set_id=sets_data)
+                if elem_list is not None:
+                    self.const_sets[sets_data] = elem_list
                     continue
 
                 # set enumerations
@@ -175,15 +182,24 @@ class TaskVariationModel(ModelBase):
         if URI_BDD_TYPE_TABLE_VAR in self.types:
             var_list = self._get_variable_list(graph=full_graph)
             rows_head = full_graph.value(subject=self.id, predicate=URI_BDD_PRED_ROWS)
-            assert isinstance(
-                rows_head, BNode
-            ), f"TableVariation '{self.id}' does not have valid 'rows' property: {rows_head}"
+            assert isinstance(rows_head, BNode), (
+                f"TableVariation '{self.id}' does not have valid 'rows' property: {rows_head}"
+            )
 
             rows = load_list_re(graph=full_graph, first_node=rows_head, parse_uri=True, quiet=True)
             for row in rows:
-                assert len(row) == len(
-                    var_list
-                ), f"TableVariation '{self.id}': row length does not match variable list: {row}"
+                assert len(row) == len(var_list), (
+                    f"TableVariation '{self.id}': row length does not match variable list: {row}"
+                )
+                # handle values for constant sets
+                for r_val in row:
+                    if not isinstance(r_val, URIRef):
+                        continue
+
+                    set_elems = try_get_const_set_elems(graph=full_graph, set_id=r_val)
+                    if set_elems is not None:
+                        self.const_sets[r_val] = set_elems
+
             self.set_attr(key=URI_BDD_PRED_VAR_LIST, val=var_list)
             self.set_attr(key=URI_BDD_PRED_ROWS, val=rows)
 
@@ -193,9 +209,9 @@ class TaskVariationModel(ModelBase):
 
     def _get_variable_list(self, graph: Graph) -> list[URIRef]:
         var_list_first_node = graph.value(subject=self.id, predicate=URI_BDD_PRED_VAR_LIST)
-        assert (
-            var_list_first_node is not None
-        ), f"TaskVariation '{self.id}' does not have 'variable-list' property"
+        assert var_list_first_node is not None, (
+            f"TaskVariation '{self.id}' does not have 'variable-list' property"
+        )
 
         var_list = []
         for var_id in graph.items(list=var_list_first_node):
@@ -208,18 +224,18 @@ class TaskVariationModel(ModelBase):
 
 def get_task_variations(task_var: TaskVariationModel) -> tuple[list[URIRef], list[Iterable[Any]]]:
     var_uri_list = task_var.get_attr(key=URI_BDD_PRED_VAR_LIST)
-    assert isinstance(
-        var_uri_list, list
-    ), f"TaskVariation '{task_var.id}' does not have a list of variables as attr"
+    assert isinstance(var_uri_list, list), (
+        f"TaskVariation '{task_var.id}' does not have a list of variables as attr"
+    )
 
     if URI_BDD_TYPE_CART_PRODUCT in task_var.types:
         var_value_sets = task_var.get_attr(key=URI_BDD_PRED_OF_SETS)
-        assert isinstance(
-            var_value_sets, list
-        ), f"TaskVariation '{task_var.id}' does not have a list of variable values as attr"
-        assert len(var_uri_list) == len(
-            var_value_sets
-        ), f"TaskVariation '{task_var.id}': number of varibles doesn't match set of values"
+        assert isinstance(var_value_sets, list), (
+            f"TaskVariation '{task_var.id}' does not have a list of variable values as attr"
+        )
+        assert len(var_uri_list) == len(var_value_sets), (
+            f"TaskVariation '{task_var.id}': number of varibles doesn't match set of values"
+        )
 
         uri_iterables = []
         for set_data in var_value_sets:
@@ -245,9 +261,17 @@ def get_task_variations(task_var: TaskVariationModel) -> tuple[list[URIRef], lis
 
     if URI_BDD_TYPE_TABLE_VAR in task_var.types:
         uri_rows = task_var.get_attr(key=URI_BDD_PRED_ROWS)
-        assert isinstance(
-            uri_rows, list
-        ), f"TaskVariation {task_var.id}: table rows are not a list: {uri_rows}"
+        assert isinstance(uri_rows, list), (
+            f"TaskVariation {task_var.id}: table rows are not a list: {uri_rows}"
+        )
+        # handle sets in row values:
+        for row_i, row in enumerate(uri_rows):
+            for col_i, cell_val in enumerate(row):
+                if not isinstance(cell_val, URIRef):
+                    continue
+                if cell_val not in task_var.const_sets:
+                    continue
+                uri_rows[row_i][col_i] = task_var.const_sets[cell_val]
         return var_uri_list, uri_rows
 
     raise RuntimeError(f"TaskVariation '{task_var.id}' has unhandled types: {task_var.types}")

--- a/src/bdd_dsl/utils/jinja.py
+++ b/src/bdd_dsl/utils/jinja.py
@@ -278,9 +278,15 @@ def get_gherkin_clauses_re(
                 f"ThereExists '{exists_model.id}': no value set for URI 'in-set', available vars: {list(var_values.keys())}"
             )
             exists_set = var_values[exists_model.in_set]
-            assert isinstance(exists_set, Iterable), (
-                f"ThereExists '{exists_model.id}': value 'in-set' not an Iterable: {exists_set}"
-            )
+            if isinstance(exists_set, str):
+                # will also raise for URIRef
+                raise ValueError(
+                    f"ThereExists '{exists_model.id}': expected a set of value, got ({type(exists_set)}): {exists_set}"
+                )
+            elif not isinstance(exists_set, Iterable):
+                raise ValueError(
+                    f"ThereExists '{exists_model.id}': value 'in-set' not an Iterable: {exists_set}"
+                )
         else:
             raise RuntimeError(
                 f"ThereExists '{exists_model.id}': unhandled type for 'in-set': {exists_model.in_set}"

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -29,7 +29,7 @@ SPEC_MODEL_URLS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/scenes/secorolab-env.scene.json": "json-ld",
     f"{URL_SECORO_M}/acceptance-criteria/bdd/scenes/isaac-agents.scene.json": "json-ld",
     f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/pickplace.tmpl.json": "json-ld",
-    f"{URL_SECORO_M}/acceptance-criteria/bdd/pickplace-secorolab-isaac.var.json": "json-ld",
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/pickplace-secorolab-isaac.var.json": "json-ld",
 }
 EXEC_MODEL_URLS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/simulation/secorolab-isaac.sim.json": "json-ld",

--- a/tests/test_bdd_spec.py
+++ b/tests/test_bdd_spec.py
@@ -15,11 +15,11 @@ MODEL_URLS = {
 }
 PP_MODELS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/pickplace.tmpl.json": "json-ld",
-    f"{URL_SECORO_M}/acceptance-criteria/bdd/pickplace-secorolab-isaac.var.json": "json-ld",
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/pickplace-secorolab-isaac.var.json": "json-ld",
 }
 SORT_MODELS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/sorting.tmpl.json": "json-ld",
-    f"{URL_SECORO_M}/acceptance-criteria/bdd/sorting-secorolab-isaac.var.json": "json-ld",
+    f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/sorting-secorolab-isaac.var.json": "json-ld",
 }
 
 


### PR DESCRIPTION
* Previously not handled, which cause error some RobBDD example.
* Default pre-commit setup applied to variation.py
* Improve err message in jinja.py
* Fix minor duplicate in RobBDD doc.
* Update variation model paths to match minhnh/models-bdd#4.