### PR TITLE
support variable scene elements

### DIFF
--- a/src/bdd_dsl/models/user_story.py
+++ b/src/bdd_dsl/models/user_story.py
@@ -132,18 +132,22 @@ class SceneModel(ModelBase):
             if URI_BDD_TYPE_SCENE_OBJ in comp_types:
                 for obj_id in full_graph.objects(subject=comp_id, predicate=URI_ENV_PRED_HAS_OBJ):
                     assert isinstance(obj_id, URIRef), (
-                        f"SceneModel {self.id}: '{obj_id}' not URIRef"
+                        f"SceneModel {self.id}: obj '{obj_id}' not URIRef"
                     )
                     self.objects.add(obj_id)
 
             if URI_BDD_TYPE_SCENE_WS in comp_types:
                 for ws_id in full_graph.objects(subject=comp_id, predicate=URI_ENV_PRED_HAS_WS):
-                    assert isinstance(ws_id, URIRef), f"SceneModel {self.id}: '{ws_id}' not URIRef"
+                    assert isinstance(ws_id, URIRef), (
+                        f"SceneModel {self.id}: ws '{ws_id}' not URIRef"
+                    )
                     self.workspaces.add(ws_id)
 
             if URI_BDD_TYPE_SCENE_AGN in comp_types:
                 for agn_id in full_graph.objects(subject=comp_id, predicate=URI_AGN_PRED_HAS_AGN):
-                    assert isinstance(agn_id, URIRef)
+                    assert isinstance(agn_id, URIRef), (
+                        f"SceneModel {self.id}: agn '{agn_id}' not URIRef"
+                    )
                     self.agents.add(agn_id)
 
     def load_obj_model(
@@ -169,6 +173,24 @@ class SceneModel(ModelBase):
         return self.agn_model_loader.load_agent_model(
             graph=graph, agent_id=agent_id, override=override, **kwargs
         )
+
+    def has_invariant_elem(self, elem_id: URIRef) -> bool:
+        return elem_id in self.objects or elem_id in self.workspaces or elem_id in self.agents
+
+    def get_variable_elems_re(self, var_val: Any, var_elems: Optional[set[URIRef]] = None) -> None:
+        if var_elems is None:
+            var_elems = set()
+
+        if isinstance(var_val, URIRef):
+            if self.has_invariant_elem(elem_id=var_val):
+                return
+            var_elems.add(var_val)
+            return
+
+        if isinstance(var_val, list):
+            for v in var_val:
+                self.get_variable_elems_re(var_val=v, var_elems=var_elems)
+            return
 
 
 class IHasClause(ModelBase):

--- a/src/bdd_dsl/models/user_story.py
+++ b/src/bdd_dsl/models/user_story.py
@@ -187,7 +187,7 @@ class SceneModel(ModelBase):
             var_elems.add(var_val)
             return
 
-        if isinstance(var_val, list):
+        if isinstance(var_val, (list, tuple)):
             for v in var_val:
                 self.get_variable_elems_re(var_val=v, var_elems=var_elems)
             return

--- a/src/bdd_dsl/models/variation.py
+++ b/src/bdd_dsl/models/variation.py
@@ -278,6 +278,6 @@ def get_task_variations(task_var: TaskVariationModel) -> tuple[list[URIRef], lis
 
 
 def get_task_var_dicts(task_var: TaskVariationModel) -> list[dict[URIRef, Any]]:
-    """Return list of varations as dictionaries mapping variables to their corresponding values"""
+    """Return list of variations as dictionaries mapping variables to their corresponding values"""
     var_uri_list, var_value_sets = get_task_variations(task_var=task_var)
     return [dict(zip(var_uri_list, val_set)) for val_set in var_value_sets]

--- a/src/bdd_dsl/models/variation.py
+++ b/src/bdd_dsl/models/variation.py
@@ -278,5 +278,6 @@ def get_task_variations(task_var: TaskVariationModel) -> tuple[list[URIRef], lis
 
 
 def get_task_var_dicts(task_var: TaskVariationModel) -> list[dict[URIRef, Any]]:
+    """Return list of varations as dictionaries mapping variables to their corresponding values"""
     var_uri_list, var_value_sets = get_task_variations(task_var=task_var)
     return [dict(zip(var_uri_list, val_set)) for val_set in var_value_sets]

--- a/src/bdd_dsl/utils/jinja.py
+++ b/src/bdd_dsl/utils/jinja.py
@@ -388,6 +388,28 @@ def prepare_scenario_variant_data(
     scr_var_name = scr_var_model.id.n3(namespace_manager=ns_manager)
     scr_var_data = {FR_NAME: scr_var_name, FR_VARIATIONS: []}
 
+    # Scene data
+    scene_data = {}
+    scene_data[FR_NAME] = scr_var_model.scene.id.n3(namespace_manager=ns_manager)
+
+    obj_list = []
+    for obj_id in scr_var_model.scene.objects:
+        obj_list.append(obj_id.n3(namespace_manager=ns_manager))
+    if len(obj_list) > 0:
+        scene_data[FR_OBJECTS] = obj_list
+
+    ws_list = []
+    for ws_id in scr_var_model.scene.workspaces:
+        ws_list.append(ws_id.n3(namespace_manager=ns_manager))
+    if len(ws_list) > 0:
+        scene_data[FR_WS] = ws_list
+
+    agn_list = []
+    for agn_id in scr_var_model.scene.agents:
+        agn_list.append(agn_id.n3(namespace_manager=ns_manager))
+    if len(agn_list) > 0:
+        scene_data[FR_AGENTS] = agn_list
+
     var_uri_list, var_vals_list = get_task_variations(scr_var_model.task_variation)
     var_count = 1
     string_gen = GherkinClauseStrGen(
@@ -398,6 +420,16 @@ def prepare_scenario_variant_data(
     for var_value_set in var_vals_list:
         var_values = dict(zip(var_uri_list, var_value_set))
 
+        # Variable scene elements
+        var_scene_elems = set()
+        var_scene_data = scene_data.copy()
+        for var_val in var_values.values():
+            scr_var_model.scene.get_variable_elems_re(var_val=var_val, var_elems=var_scene_elems)
+        if len(var_scene_elems) > 0:
+            var_scene_data["elements"] = [
+                elem_id.n3(namespace_manager=ns_manager) for elem_id in var_scene_elems
+            ]
+
         clauses = []
         get_gherkin_clauses_re(
             has_clause_model=scr_var_model,
@@ -407,7 +439,7 @@ def prepare_scenario_variant_data(
             clause_list=clauses,
         )
         scr_var_data[FR_VARIATIONS].append(
-            {FR_NAME: f"{scr_var_name} -- {var_count}", "clauses": clauses}
+            {FR_NAME: f"{scr_var_name} -- {var_count}", "clauses": clauses, "scene": var_scene_data}
         )
         var_count += 1
 
@@ -439,34 +471,6 @@ def prepare_jinja2_template_data(
 
         for scr_var_id in scr_var_set:
             scr_var = us_loader.load_scenario_variant(full_graph=full_graph, variant_id=scr_var_id)
-
-            # Scene data
-            scene_id_str = scr_var.scene.id.n3(namespace_manager=ns_manager)
-            if FR_NAME not in scene_data:
-                scene_data[FR_NAME] = scene_id_str
-
-                obj_list = []
-                for obj_id in scr_var.scene.objects:
-                    obj_list.append(obj_id.n3(namespace_manager=ns_manager))
-                if len(obj_list) > 0:
-                    scene_data[FR_OBJECTS] = obj_list
-
-                ws_list = []
-                for ws_id in scr_var.scene.workspaces:
-                    ws_list.append(ws_id.n3(namespace_manager=ns_manager))
-                if len(ws_list) > 0:
-                    scene_data[FR_WS] = ws_list
-
-                agn_list = []
-                for agn_id in scr_var.scene.agents:
-                    agn_list.append(agn_id.n3(namespace_manager=ns_manager))
-                if len(agn_list) > 0:
-                    scene_data[FR_AGENTS] = agn_list
-            else:
-                if scene_id_str != scene_data[FR_NAME]:
-                    raise ValueError(
-                        f"can't handle multiple scenes for US '{us_id_str}': {scene_data[FR_NAME]}, {scene_id_str}"
-                    )
 
             # ScenarioVariant data
             scr_var_data = prepare_scenario_variant_data(

--- a/src/bdd_dsl/utils/jinja.py
+++ b/src/bdd_dsl/utils/jinja.py
@@ -11,7 +11,6 @@ from bdd_dsl.models.clauses import (
 from bdd_dsl.models.frames import (
     FR_AGENTS,
     FR_OBJECTS,
-    FR_SCENE,
     FR_NAME,
     FR_CRITERIA,
     FR_VARIATIONS,
@@ -464,11 +463,6 @@ def prepare_jinja2_template_data(
         us_id_str = us_id.n3(namespace_manager=ns_manager)
         us_data = {FR_NAME: us_id_str, FR_CRITERIA: []}
 
-        # TODO(minhnh): handles a UserStory having multiple scenes, since scenes are linked to
-        # a ScenarioTemplate, multiple of which can appear in a UserStory. This can perhaps be
-        # a constraint on USs, but for now just raise an error
-        scene_data = {}
-
         for scr_var_id in scr_var_set:
             scr_var = us_loader.load_scenario_variant(full_graph=full_graph, variant_id=scr_var_id)
 
@@ -482,8 +476,6 @@ def prepare_jinja2_template_data(
             )
 
             us_data[FR_CRITERIA].append(scr_var_data)
-
-        us_data[FR_SCENE] = scene_data
 
         jinja_data.append(us_data)
 


### PR DESCRIPTION
* Add methods to check for any variable elements not already included in the scene, which are added via scenario variable and variation specifications.
* Modify jinja module to generate separate scenes for each scenario variations, including variable elements. This depends on corresponding Jinja template changes in minhnh/models-bdd#7
* resolve #16 
* This won't fail tests, but correct Gherkin generation will require secorolab/models#16 to be merged.