### PR TITLE
Migrate environment & agent vocabs to rdf-utils, fix ruff check issues 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.4
+  rev: v0.16.0
   hooks:
     - id: ruff-check
       args: [ --fix ]

--- a/examples/create_bt_with_events.py
+++ b/examples/create_bt_with_events.py
@@ -1,17 +1,17 @@
-from os.path import join, dirname
+from os.path import dirname, join
+
+from bdd_dsl.behaviours.robosuite import SimulatedScenario
+from bdd_dsl.events.zmq import ZmqEventClient
 
 # import py_trees as pt
 # from pprint import pprint
 from bdd_dsl.utils.json import (
-    load_metamodels,
     create_bt_from_graph,
     create_event_handler_from_data,
-    get_bt_event_data_from_graph,
     create_subtree_behaviours,
+    get_bt_event_data_from_graph,
+    load_metamodels,
 )
-from bdd_dsl.behaviours.robosuite import SimulatedScenario
-from bdd_dsl.events.zmq import ZmqEventClient
-
 
 PKG_ROOT = join(dirname(__file__), "..")
 MODELS_PATH = join(PKG_ROOT, "models")

--- a/examples/generate_bdd_specs.py
+++ b/examples/generate_bdd_specs.py
@@ -1,19 +1,20 @@
 import sys
-from os.path import join, dirname
 from enum import StrEnum
+from os.path import dirname, join
 from timeit import default_timer as timer
 from urllib.request import HTTPError
-import rdflib
 
-from rdf_utils.uri import URL_SECORO_M
-from rdf_utils.resolver import install_resolver
+import rdflib
 from rdf_utils.naming import get_valid_filename
+from rdf_utils.resolver import install_resolver
+from rdf_utils.uri import URL_SECORO_M
+
+from bdd_dsl.models.frames import FR_NAME
 from bdd_dsl.models.user_story import UserStoryLoader
 from bdd_dsl.utils.jinja import (
     load_template_from_url,
     prepare_jinja2_template_data,
 )
-from bdd_dsl.models.frames import FR_NAME
 
 
 class ExampleType(StrEnum):

--- a/examples/generated/environment.py
+++ b/examples/generated/environment.py
@@ -3,13 +3,14 @@ import sys
 import time
 from json import JSONDecodeError
 from urllib.error import HTTPError
+
 from behave.model import Step
 from behave.runner import Context
-from rdflib import Dataset
-from rdf_utils.uri import URL_SECORO_M
 from rdf_utils.resolver import install_resolver
-from bdd_dsl.execution.mockup import before_all_mockup, before_scenario
+from rdf_utils.uri import URL_SECORO_M
+from rdflib import Dataset
 
+from bdd_dsl.execution.mockup import before_all_mockup, before_scenario
 
 MODELS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/agents/isaac-sim.agn.json": "json-ld",

--- a/examples/generated/steps/imported_steps.py
+++ b/examples/generated/steps/imported_steps.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 from behave import given, then, when
+
 from bdd_dsl.behave import (
     CLAUSE_BG_AGENTS,
     CLAUSE_BG_OBJECTS,
@@ -14,15 +15,14 @@ from bdd_dsl.behave import (
     CLAUSE_TC_DURING,
 )
 from bdd_dsl.execution.mockup import (
+    behaviour_mockup,
+    given_agents_mockup,
     given_objects_mockup,
     given_scene_mockup,
     given_workspaces_mockup,
-    given_agents_mockup,
     is_located_at_mockup,
     move_safe_mockup,
-    behaviour_mockup,
 )
-
 
 given(CLAUSE_BG_OBJECTS)(given_objects_mockup)
 given(CLAUSE_BG_WORKSPACES)(given_workspaces_mockup)

--- a/src/bdd_dsl/__init__.py
+++ b/src/bdd_dsl/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 from importlib.metadata import version
 
-
 __version__ = version("bdd-dsl")

--- a/src/bdd_dsl/bdd/behave_fixtures.py
+++ b/src/bdd_dsl/bdd/behave_fixtures.py
@@ -1,18 +1,22 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-import time
-import multiprocessing
 import logging
+import multiprocessing
+import time
+
 from behave import fixture
 from behave.runner import Context
-from bdd_dsl.events.zmq import ZmqEventServer, ZmqEventClient
-from bdd_dsl.exception import GracefulExit
+
 from bdd_dsl.behaviours.robosuite import SimulatedScenario
+from bdd_dsl.events.zmq import ZmqEventClient, ZmqEventServer
+from bdd_dsl.exception import GracefulExit
+from bdd_dsl.models.frames import FR_EVENTS, FR_NAME
 from bdd_dsl.utils.json import create_event_handler_from_data, create_subtree_behaviours
-from bdd_dsl.models.frames import FR_NAME, FR_EVENTS
+
+logger = logging.getLogger(__name__)
 
 
 def zmq_event_server_process(**kwargs):
-    event_names = kwargs.get("event_names", list())
+    event_names = kwargs.get("event_names", [])
     if not event_names:
         raise ValueError("'event_names' not specified or empty list of events")
     hostname = kwargs.get("hostname", "*")
@@ -25,7 +29,7 @@ def zmq_event_server_process(**kwargs):
             server.handle_request()
             time.sleep(sleep_time)
         except GracefulExit as e:
-            logging.info(f"zmq_event_server_process: terminating with signum '{e.signum}'")
+            logger.info(f"zmq_event_server_process: terminating with signum '{e.signum}'")
             break
 
 
@@ -39,7 +43,7 @@ def setup_event_server(context: Context, *args, **kwargs):
         event_server_process.start()
         context.add_cleanup(event_server_process.terminate)
     except GracefulExit as e:
-        logging.info(f"setup_event_server: terminating with signum '{e.signum}'")
+        logger.info(f"setup_event_server: terminating with signum '{e.signum}'")
 
 
 def sim_execution_process(**kwargs):
@@ -67,7 +71,7 @@ def sim_execution_process(**kwargs):
             done = pickup_scenario.step()
         except GracefulExit as e:
             pickup_scenario.interrupt()
-            logging.info(f"sim_execution_process: terminating with signum '{e.signum}'")
+            logger.info(f"sim_execution_process: terminating with signum '{e.signum}'")
             break
 
 
@@ -80,4 +84,4 @@ def setup_sim(context: Context, *args, **kwargs):
         sim_process.start()
         context.add_cleanup(sim_process.terminate)
     except GracefulExit as e:
-        logging.info(f"setup_event_server: terminating with signum '{e.signum}'")
+        logger.info(f"setup_event_server: terminating with signum '{e.signum}'")

--- a/src/bdd_dsl/behave.py
+++ b/src/bdd_dsl/behave.py
@@ -1,16 +1,18 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from enum import Enum
-from typing import Any, Generator, Union
 from ast import literal_eval
+from collections.abc import Generator
+from enum import Enum
+from typing import Any
+
 from behave.model import Table
-from rdflib import Graph
-from rdflib.term import Node as RDFNode
-from rdflib.namespace import NamespaceManager
 from rdf_utils.uri import try_parse_n3_iterable, try_parse_n3_string
+from rdflib import Graph
+from rdflib.namespace import NamespaceManager
+from rdflib.term import Node as RDFNode
+
 from bdd_dsl.models.agent import AgentModel
 from bdd_dsl.models.environment import ObjectModel, WorkspaceModel
 from bdd_dsl.models.user_story import SceneModel
-
 
 PARAM_OBJ = "obj_str"
 PARAM_WS = "ws_str"
@@ -90,7 +92,7 @@ class ParamType(Enum):
 
 def parse_str_param(
     param_str: str, ns_manager: NamespaceManager
-) -> tuple[ParamType, list[Union[RDFNode, str]]]:
+) -> tuple[ParamType, list[RDFNode | str]]:
     # ThereExists string representation: 'any of [set items]'
     if param_str.startswith("any of "):
         list_str = param_str.split("any of ")[1]
@@ -99,9 +101,9 @@ def parse_str_param(
         except SyntaxError as e:
             raise RuntimeError(f"unable to parse '{list_str}': {e}")
 
-        assert isinstance(
-            n3_str_list, list
-        ), f"can't parse as a list (type={type(n3_str_list)}): {list_str}"
+        assert isinstance(n3_str_list, list), (
+            f"can't parse as a list (type={type(n3_str_list)}): {list_str}"
+        )
 
         n3_term_list = try_parse_n3_iterable(
             n3_str_iterable=n3_str_list, ns_manager=ns_manager, quiet=False
@@ -116,9 +118,9 @@ def parse_str_param(
         except SyntaxError as e:
             raise RuntimeError(f"unable to parse '{param_str}': {e}")
 
-        assert isinstance(
-            n3_str_list, list
-        ), f"can't parse as a list (type={type(n3_str_list)}): {param_str}"
+        assert isinstance(n3_str_list, list), (
+            f"can't parse as a list (type={type(n3_str_list)}): {param_str}"
+        )
 
         n3_term_list = try_parse_n3_iterable(
             n3_str_iterable=n3_str_list, ns_manager=ns_manager, quiet=False

--- a/src/bdd_dsl/behaviours/actions.py
+++ b/src/bdd_dsl/behaviours/actions.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 import abc
-from bdd_dsl.events.event_handler import EventHandler
+
 from py_trees.behaviour import Behaviour as PTBehaviour
 from py_trees.common import Status as PTStatus
+
+from bdd_dsl.events.event_handler import EventHandler
 
 
 class ActionWithEvents(PTBehaviour, metaclass=abc.ABCMeta):

--- a/src/bdd_dsl/behaviours/mockup.py
+++ b/src/bdd_dsl/behaviours/mockup.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 import time
-from bdd_dsl.behaviours.actions import ActionWithEvents
+
 from py_trees.common import Status as PTStatus
+
+from bdd_dsl.behaviours.actions import ActionWithEvents
 
 
 class Heartbeat(ActionWithEvents):

--- a/src/bdd_dsl/behaviours/robosuite.py
+++ b/src/bdd_dsl/behaviours/robosuite.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 import time
+
 import numpy as np
-import robosuite as rs
 import py_trees as pt
+import robosuite as rs
+
 from bdd_dsl.behaviours.actions import ActionWithEvents
 from bdd_dsl.events.event_handler import EventHandler
 
 # from pprint import pprint
 
 
-class SimulatedScenario(object):
+class SimulatedScenario:
     def __init__(
         self,
         event_handler: EventHandler,
@@ -65,7 +67,7 @@ class SimulatedScenario(object):
         try:
             # actions = np.random.randn(self.env.robots[0].dof)  # sample random action
             actions = self.blackboard.actions
-            obs, reward, done, info = self.env.step(actions)  # take action in the environment
+            obs, _reward, done, _info = self.env.step(actions)  # take action in the environment
             # pprint(obs)
             self.blackboard.measurements = obs
         except KeyError:

--- a/src/bdd_dsl/events/event_handler.py
+++ b/src/bdd_dsl/events/event_handler.py
@@ -1,15 +1,14 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from abc import abstractmethod, ABC
-from typing import List
+from abc import ABC, abstractmethod
 
 
 class EventHandler(ABC):
-    def __init__(self, id: str, events: List[str]) -> None:
+    def __init__(self, id: str, events: list[str]) -> None:
         self.id = id
         self._events = events
 
     @property
-    def event_names(self) -> List[str]:
+    def event_names(self) -> list[str]:
         return self._events
 
     @abstractmethod
@@ -26,7 +25,7 @@ class EventHandler(ABC):
 
 
 class SimpleEventLoop(EventHandler):
-    def __init__(self, id: str, events: List[str]) -> None:
+    def __init__(self, id: str, events: list[str]) -> None:
         super().__init__(id, events)
         self._current_events = {}
         self._future_events = {}

--- a/src/bdd_dsl/events/zmq.py
+++ b/src/bdd_dsl/events/zmq.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from enum import StrEnum, IntEnum
 import logging
 import time
-from typing import List
+from enum import IntEnum, StrEnum
+
 import zmq
+
 from bdd_dsl.events.event_handler import EventHandler
+
+logger = logging.getLogger(__name__)
 
 
 class MessageKey(StrEnum):
@@ -31,11 +34,11 @@ class EventDataKey(StrEnum):
     SOURCE = "SOURCE"
 
 
-class ZmqEventServer(object):
+class ZmqEventServer:
     def __init__(
         self,
         id: str,
-        events: List[str],
+        events: list[str],
         hostname: str = "*",
         port: int = 5555,
         queue_size: int = 10,
@@ -75,7 +78,7 @@ class ZmqEventServer(object):
             or MessageKey.DATA not in message
             or EventDataKey.ID not in message[MessageKey.DATA]
         ):
-            logging.error(f"request missing required fields: {message}")
+            logger.error(f"request missing required fields: {message}")
             response[MessageKey.STATUS] = ResponseType.INVALID_REQUEST
             self._socket.send_json(response)
             return message
@@ -106,7 +109,7 @@ class ZmqEventServer(object):
 
         else:
             # unrecognized request type
-            logging.error(f"invalid request type: {req_type}")
+            logger.error(f"invalid request type: {req_type}")
             response[MessageKey.STATUS] = ResponseType.INVALID_REQUEST
 
         # send response
@@ -115,7 +118,7 @@ class ZmqEventServer(object):
 
 
 class ZmqEventClient(EventHandler):
-    def __init__(self, id: str, events: List[str], hostname="localhost", port=5555):
+    def __init__(self, id: str, events: list[str], hostname="localhost", port=5555):
         super().__init__(id, events)
         self.hostname = hostname
         self.port = port
@@ -134,9 +137,7 @@ class ZmqEventClient(EventHandler):
         resp = self._send_request(
             {MessageKey.TYPE: RequestType.CONSUME, MessageKey.DATA: {EventDataKey.ID: event_id}}
         )
-        if resp[MessageKey.STATUS] == ResponseType.UNRECOGNIZED_EVENT:
-            return False
-        return True
+        return resp[MessageKey.STATUS] != ResponseType.UNRECOGNIZED_EVENT
 
     def produce(self, event_id: str) -> None:
         self._send_request(

--- a/src/bdd_dsl/execution/behaviour.py
+++ b/src/bdd_dsl/execution/behaviour.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 from abc import ABC, abstractmethod
-from typing import Any, Optional
-from rdflib import Graph, URIRef
+from typing import Any
+
 from behave.runner import Context
 from rdf_utils.models.common import ModelBase, get_node_types
+from rdflib import Graph, URIRef
+
 from bdd_dsl.models.urirefs import URI_BHV_PRED_OF_BHV
 
 
@@ -28,7 +30,7 @@ class Behaviour(ModelBase, ABC):
 
 
 class BehaviourImplModel(ModelBase):
-    behaviour: Optional[Behaviour]
+    behaviour: Behaviour | None
     behaviour_uri: URIRef
     behaviour_types: set[URIRef]
 

--- a/src/bdd_dsl/execution/common.py
+++ b/src/bdd_dsl/execution/common.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 from __future__ import annotations
+
 import json
 from typing import Any
+
 from rdf_utils.models.common import ModelBase
-from rdflib import Graph
-from rdf_utils.namespace import URL_SECORO_M, URL_SECORO_MM
 from rdf_utils.models.vocab import (
     URI_EXEC_PRED_HAS_CONFIG,
 )
-
+from rdf_utils.namespace import URL_SECORO_M, URL_SECORO_MM
+from rdflib import Graph
 
 URL_Q_SCENARIO_EXEC = f"{URL_SECORO_M}/acceptance-criteria/bdd/queries/scenario-execution.rq"
 URL_MM_EXEC_SHACL = f"{URL_SECORO_MM}/acceptance-criteria/bdd/execution-context.shacl.ttl"

--- a/src/bdd_dsl/execution/mockup.py
+++ b/src/bdd_dsl/execution/mockup.py
@@ -1,34 +1,36 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 from time import sleep
-from typing import Any, Optional
-from behave.runner import Context
+from typing import Any
+
 from behave.model import Scenario
-from rdflib import Graph
+from behave.runner import Context
 from rdf_utils.models.common import ModelLoader, URIRef
+from rdf_utils.models.execution import load_attr_path
 from rdf_utils.models.python import (
-    URI_PY_TYPE_MODULE_ATTR,
     URI_PY_PRED_ATTR_NAME,
     URI_PY_PRED_MODULE_NAME,
+    URI_PY_TYPE_MODULE_ATTR,
     load_py_module_attr,
 )
-from rdf_utils.models.execution import load_attr_path
 from rdf_utils.models.vocab import URI_EXEC_PRED_PATH, URI_EXEC_TYPE_RES_PATH
 from rdf_utils.uri import NamespaceManager, try_expand_curie
+from rdflib import Graph
+
 from bdd_dsl.behave import (
+    PARAM_AGN,
     PARAM_EVT,
     PARAM_FROM_EVT,
-    PARAM_UNTIL_EVT,
-    PARAM_AGN,
     PARAM_OBJ,
+    PARAM_UNTIL_EVT,
     PARAM_WS,
-    load_obj_models_from_table,
     load_agn_models_from_table,
+    load_obj_models_from_table,
     load_str_params,
     load_ws_models_from_table,
     parse_str_param,
 )
-from bdd_dsl.execution.common import load_attr_has_config
 from bdd_dsl.execution.behaviour import Behaviour
+from bdd_dsl.execution.common import load_attr_has_config
 from bdd_dsl.execution.scenario import ExecutionModel
 from bdd_dsl.models.user_story import ScenarioVariantModel, UserStoryLoader
 
@@ -220,9 +222,9 @@ def move_safe_mockup(context: Context, **kwargs: Any):
 
 
 class PickplaceBehaviourMockup(Behaviour):
-    agn_ids: Optional[list[URIRef]]
-    obj_ids: Optional[list[URIRef]]
-    place_ws_ids: Optional[list[URIRef]]
+    agn_ids: list[URIRef] | None
+    obj_ids: list[URIRef] | None
+    place_ws_ids: list[URIRef] | None
 
     def __init__(
         self,

--- a/src/bdd_dsl/execution/scenario.py
+++ b/src/bdd_dsl/execution/scenario.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 from typing import Any
+
 from behave.runner import Context
-from rdf_utils.models.common import AttrLoaderProtocol, ModelBase, ModelLoader
-from rdflib import Graph, URIRef
 from rdf_utils.caching import read_url_and_cache
+from rdf_utils.models.common import AttrLoaderProtocol, ModelBase, ModelLoader
 from rdf_utils.models.python import (
     URI_PY_TYPE_MODULE_ATTR,
     import_attr_from_model,
 )
+from rdflib import Graph, URIRef
+
 from bdd_dsl.execution.behaviour import Behaviour, BehaviourImplModel
 from bdd_dsl.execution.common import URL_Q_SCENARIO_EXEC
 from bdd_dsl.models.time_constraint import get_duration
@@ -70,7 +72,7 @@ class ScenarioExecutionModel(ModelBase):
         # Behaviour Implementation model
         bhv_impl_id = graph.value(subject=self.id, predicate=URI_BDD_PRED_HAS_BHV_IMPL, any=False)
         if not isinstance(bhv_impl_id, URIRef):
-            raise ValueError(
+            raise TypeError(
                 f"ScenarioExecution '{self.id}' doesn't link to a BehaviourImplementation URI: {bhv_impl_id}"
             )
         self.bhv_impl = BehaviourImplModel(graph=graph, bhv_impl_id=bhv_impl_id)
@@ -81,13 +83,13 @@ class ScenarioExecutionModel(ModelBase):
         self.obs_policy_uris = set()
         for obs_pol_id in graph.objects(subject=self.id, predicate=URI_OBS_PRED_POLICY):
             if not isinstance(obs_pol_id, URIRef):
-                raise ValueError(
+                raise TypeError(
                     f"ScenarioExecution {self.id} doesn't link to an ObservationPolicy URI: {obs_pol_id}"
                 )
             self.obs_policy_uris.add(obs_pol_id)
 
 
-class ExecutionModel(object):
+class ExecutionModel:
     _bhv_impl_by_scr_var: dict[URIRef, BehaviourImplModel]
     _scr_exec_by_scr_var: dict[URIRef, ModelBase]
     _scr_exec_graph: Graph

--- a/src/bdd_dsl/models/agent.py
+++ b/src/bdd_dsl/models/agent.py
@@ -1,16 +1,18 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from typing import Any, Dict, Optional
-from rdflib import Graph, URIRef
+from typing import Any
+
 from rdf_utils.models.common import AttrLoaderProtocol, ModelBase, ModelLoader
+from rdf_utils.models.vocab import URI_AGN_PRED_HAS_AGN_MODEL
+from rdflib import Graph, URIRef
+
 from bdd_dsl.execution.common import load_attr_has_config
 from bdd_dsl.models.queries import Q_MODELLED_AGENT
-from bdd_dsl.models.urirefs import URI_AGN_PRED_HAS_AGN_MODEL
 
 
 class AgentModel(ModelBase):
-    models: Dict[URIRef, ModelBase]
+    models: dict[URIRef, ModelBase]
     model_types: set[URIRef]
-    model_type_to_id: Dict[URIRef, set[URIRef]]  # map a model type to a set of model URIs
+    model_type_to_id: dict[URIRef, set[URIRef]]  # map a model type to a set of model URIs
 
     def __init__(self, graph: Graph, agent_id: URIRef) -> None:
         super().__init__(graph=graph, node_id=agent_id)
@@ -47,10 +49,10 @@ class AgentModel(ModelBase):
         raise RuntimeError(f"object '{self.id}' doesn't have a model of type '{model_type}'")
 
 
-class AgnModelLoader(object):
+class AgnModelLoader:
     _model_loader: ModelLoader
-    _modelled_agn_g: Optional[Graph]
-    _agn_models: Dict[URIRef, AgentModel]
+    _modelled_agn_g: Graph | None
+    _agn_models: dict[URIRef, AgentModel]
 
     def __init__(self):
         self._agn_models = {}  # Agent URI -> AgentModel instance

--- a/src/bdd_dsl/models/clauses.py
+++ b/src/bdd_dsl/models/clauses.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from typing import Optional, Protocol
-from rdflib import BNode, Literal, URIRef, Graph
-from rdf_utils.models.common import ModelBase
+from typing import Protocol
+
 from rdf_utils.collection import load_list_re
+from rdf_utils.models.common import ModelBase
+from rdflib import BNode, Graph, Literal, URIRef
+
 from bdd_dsl.exception import BDDConstraintViolation
+from bdd_dsl.models.time_constraint import process_time_constraint_model
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_ARG_NAMES,
     URI_BDD_PRED_ARG_VARS,
@@ -29,10 +32,9 @@ from bdd_dsl.models.urirefs import (
     URI_BHV_TYPE_PLACE,
     URI_TIME_TYPE_TC,
 )
-from bdd_dsl.models.time_constraint import process_time_constraint_model
 
 
-class IClause(object):
+class IClause:
     clause_of: URIRef
 
     def __init__(self, node_id: URIRef, graph: Graph) -> None:
@@ -47,7 +49,7 @@ class FluentClauseModel(ModelBase, IClause):
     variable_by_role: dict[URIRef, list[URIRef]]  # map role URI -> ScenarioVariable URIs
     variables: set[URIRef]
 
-    def __init__(self, graph: Graph, clause_id: URIRef, types: Optional[set[URIRef]]) -> None:
+    def __init__(self, graph: Graph, clause_id: URIRef, types: set[URIRef] | None) -> None:
         ModelBase.__init__(self, graph=graph, node_id=clause_id, types=types)
         IClause.__init__(self, node_id=clause_id, graph=graph)
 
@@ -92,24 +94,19 @@ def load_located_at_info(graph: Graph, clause: FluentClauseModel) -> None:
             f" does not refer to exactly 1 workspace: {clause.variable_by_role[URI_BDD_PRED_REF_WS]}"
         )
 
-    return
-
 
 def load_held_by_info(graph: Graph, clause: FluentClauseModel) -> None:
     clause.add_variables_by_role(graph=graph, role_pred=URI_BDD_PRED_REF_OBJ)
     clause.add_variables_by_role(graph=graph, role_pred=URI_BDD_PRED_REF_AGN)
-    return
 
 
 def load_move_safe_info(graph: Graph, clause: FluentClauseModel) -> None:
     clause.add_variables_by_role(graph=graph, role_pred=URI_BDD_PRED_REF_AGN)
-    return
 
 
 def load_sorted_info(graph: Graph, clause: FluentClauseModel) -> None:
     clause.add_variables_by_role(graph=graph, role_pred=URI_BDD_PRED_REF_OBJ)
     clause.add_variables_by_role(graph=graph, role_pred=URI_BDD_PRED_REF_WS)
-    return
 
 
 def load_has_config_info(graph: Graph, clause: FluentClauseModel) -> None:
@@ -126,7 +123,6 @@ def load_has_config_info(graph: Graph, clause: FluentClauseModel) -> None:
         f"HasConfig Pred '{clause.id}' missing 'config-name' pred to Literal: {cfg_name}"
     )
     clause.set_attr(key=URI_BDD_PRED_CFG_NAME, val=cfg_name.toPython())
-    return
 
 
 def get_clause_config(clause: FluentClauseModel) -> tuple[URIRef, str, URIRef]:
@@ -176,7 +172,7 @@ DEFAULT_FLUENT_LOADERS = {
 }
 
 
-class FluentClauseLoader(object):
+class FluentClauseLoader:
     _loaders: dict[URIRef, FluentClauseLoaderProtocol]
 
     def __init__(self, loaders: dict[URIRef, FluentClauseLoaderProtocol]) -> None:
@@ -247,7 +243,7 @@ def load_bhv_pickplace(graph: Graph, when_bhv: WhenBehaviourModel) -> None:
         when_bhv.set_attr(key=URI_BHV_PRED_TARGET_WS, val=target_ws_id)
 
 
-class WhenBhvLoader(object):
+class WhenBhvLoader:
     _loaders: list[WhenBhvLoaderProtocol]
 
     def __init__(self, loaders: list[WhenBhvLoaderProtocol]) -> None:

--- a/src/bdd_dsl/models/environment.py
+++ b/src/bdd_dsl/models/environment.py
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from typing import Any, Optional, Generator
-from rdflib import Graph, URIRef
-from rdflib.exceptions import UniquenessError
+from collections.abc import Generator
+from typing import Any
+
 from rdf_utils.models.common import AttrLoaderProtocol, ModelBase, ModelLoader, get_node_types
-from bdd_dsl.execution.common import load_attr_has_config
-from bdd_dsl.models.queries import Q_MODELLED_OBJECT
-from bdd_dsl.models.urirefs import (
+from rdf_utils.models.vocab import (
     URI_ENV_PRED_HAS_OBJ,
     URI_ENV_PRED_HAS_OBJ_MODEL,
     URI_ENV_PRED_HAS_WS,
@@ -13,6 +11,11 @@ from bdd_dsl.models.urirefs import (
     URI_ENV_TYPE_WS_OBJ,
     URI_ENV_TYPE_WS_WS,
 )
+from rdflib import Graph, URIRef
+from rdflib.exceptions import UniquenessError
+
+from bdd_dsl.execution.common import load_attr_has_config
+from bdd_dsl.models.queries import Q_MODELLED_OBJECT
 
 
 class ObjectModel(ModelBase):
@@ -70,7 +73,7 @@ class WorkspaceModel(ModelBase):
 
 
 def _get_ws_objects_re(
-    ws_id: URIRef, ws_dict: dict[URIRef, WorkspaceModel], ws_path: Optional[set[URIRef]] = None
+    ws_id: URIRef, ws_dict: dict[URIRef, WorkspaceModel], ws_path: set[URIRef] | None = None
 ) -> Generator[URIRef, None, None]:
     if ws_path is None:
         ws_path = set()
@@ -95,7 +98,7 @@ def _load_ws_re(
     ws_id: URIRef,
     graph: Graph,
     ws_dict: dict[URIRef, WorkspaceModel],
-    ws_path: Optional[set[URIRef]] = None,
+    ws_path: set[URIRef] | None = None,
 ) -> None:
     if ws_path is None:
         ws_path = set()
@@ -135,9 +138,9 @@ def _load_ws_re(
             _load_ws_re(ws_id=sub_ws_id, graph=graph, ws_dict=ws_dict, ws_path=ws_path)
 
 
-class EnvModelLoader(object):
+class EnvModelLoader:
     _model_loader: ModelLoader
-    _modelled_obj_g: Optional[Graph]
+    _modelled_obj_g: Graph | None
     _obj_models: dict[URIRef, ObjectModel]
     _ws_models: dict[URIRef, WorkspaceModel]
 

--- a/src/bdd_dsl/models/frames.py
+++ b/src/bdd_dsl/models/frames.py
@@ -1,28 +1,28 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from bdd_dsl.models.uri import (
-    URI_TRANS,
-    URI_MM_EVENT,
-    URI_MM_BT,
-    URI_M_CRDN,
-)
 from bdd_dsl.models.namespace import (
     PREFIX_TRANS,
 )
 from bdd_dsl.models.queries import (
-    Q_HAS_EVENT,
-    Q_HAS_ROOT,
-    Q_HAS_EL_CONN,
     Q_HAS_CHILD,
-    Q_HAS_PARENT,
-    Q_HAS_START_E,
+    Q_HAS_EL_CONN,
     Q_HAS_END_E,
-    Q_IMPL_MODULE,
-    Q_IMPL_CLASS,
+    Q_HAS_EVENT,
+    Q_HAS_PARENT,
+    Q_HAS_ROOT,
+    Q_HAS_START_E,
+    Q_HAS_SUBTREE,
     Q_IMPL_ARG_NAME,
     Q_IMPL_ARG_VALUE,
-    Q_PREFIX_EVENT,
+    Q_IMPL_CLASS,
+    Q_IMPL_MODULE,
     Q_PREFIX_BT,
-    Q_HAS_SUBTREE,
+    Q_PREFIX_EVENT,
+)
+from bdd_dsl.models.uri import (
+    URI_M_CRDN,
+    URI_MM_BT,
+    URI_MM_EVENT,
+    URI_TRANS,
 )
 
 FR_NAME = "name"

--- a/src/bdd_dsl/models/namespace.py
+++ b/src/bdd_dsl/models/namespace.py
@@ -1,12 +1,13 @@
-from rdflib import Namespace, Graph
-from rdf_utils.namespace import NS_MM_GEOM, NS_MM_GEOM_REL, NS_MM_GEOM_COORD, NS_MM_ENV
+from rdf_utils.namespace import NS_MM_ENV, NS_MM_GEOM, NS_MM_GEOM_COORD, NS_MM_GEOM_REL
+from rdflib import Graph, Namespace
+
 from bdd_dsl.models.uri import (
     URI_MM_BDD,
     URI_MM_BHV,
-    URI_MM_SIM,
     URI_MM_OBS,
-    URI_MM_TASK,
     URI_MM_ROS,
+    URI_MM_SIM,
+    URI_MM_TASK,
 )
 
 # Namespaces

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -1,14 +1,17 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 from __future__ import annotations
+
+from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any, Generator, Optional, Protocol
-from trinary import Trinary, Unknown
-from rdflib import Graph, URIRef
+from typing import Any, Protocol
+
 from rdf_utils.models.common import AttrLoaderProtocol, ModelBase
+from rdflib import Graph, URIRef
+from trinary import Trinary, Unknown
+
 from bdd_dsl.execution.scenario import ScenarioExecutionModel
-from bdd_dsl.models.time_constraint import get_duration
-from bdd_dsl.models.user_story import ScenarioVariantModel
 from bdd_dsl.models.clauses import FluentClauseModel
+from bdd_dsl.models.time_constraint import get_duration
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_OF_CLAUSE,
     URI_OBS_TYPE_POLICY,
@@ -19,6 +22,7 @@ from bdd_dsl.models.urirefs import (
     URI_TIME_TYPE_BEFORE_EVT,
     URI_TIME_TYPE_DURING,
 )
+from bdd_dsl.models.user_story import ScenarioVariantModel
 
 
 @dataclass
@@ -47,15 +51,15 @@ def trin_policy_and(trinaries: list[TrinaryStamped], **kwargs: Any) -> bool | Tr
 class ObsPolicyModel(ModelBase):
     trinary_timeline: list[TrinaryStamped]
 
-    start_time: Optional[float]
-    end_time: Optional[float]
+    start_time: float | None
+    end_time: float | None
 
     fluent_id: URIRef
     fluent_types: set[URIRef]
     duration_type: URIRef
-    start_event: Optional[URIRef]
-    end_event: Optional[URIRef]
-    horizon: Optional[float]
+    start_event: URIRef | None
+    end_event: URIRef | None
+    horizon: float | None
 
     def __init__(
         self,
@@ -64,9 +68,9 @@ class ObsPolicyModel(ModelBase):
         fluent_id: URIRef,
         fluent_types: set[URIRef],
         duration_type: URIRef,
-        start_event: Optional[URIRef],
-        end_event: Optional[URIRef],
-        horizon: Optional[float],
+        start_event: URIRef | None,
+        end_event: URIRef | None,
+        horizon: float | None,
     ) -> None:
         super().__init__(node_id=node_id, graph=graph)
         if URI_OBS_TYPE_POLICY not in self.types:
@@ -234,7 +238,7 @@ class ObsPolicyModel(ModelBase):
 
         for obs_pol_id in graph.subjects(predicate=URI_BDD_PRED_OF_CLAUSE, object=fc.id):
             if not isinstance(obs_pol_id, URIRef):
-                raise ValueError(
+                raise TypeError(
                     f"Fluent '{fc.id}' is not linked via 'of-clause' to a ObservationPolicy URI: {obs_pol_id}"
                 )
 
@@ -250,12 +254,12 @@ class ObsPolicyModel(ModelBase):
             )
 
 
-class ObservationManager(object):
+class ObservationManager:
     scenario_exec: ScenarioExecutionModel
-    scr_start_time: Optional[float]
-    scr_end_time: Optional[float]
+    scr_start_time: float | None
+    scr_end_time: float | None
 
-    bhv_result: Optional[TrinaryStamped]
+    bhv_result: TrinaryStamped | None
 
     obs_policies: dict[URIRef, ObsPolicyModel]  # policy ID -> ObsPolicyModel
     _fluent_policy_registry: dict[URIRef, set[URIRef]]  # fluent ID -> policy IDs

--- a/src/bdd_dsl/models/queries.py
+++ b/src/bdd_dsl/models/queries.py
@@ -1,19 +1,27 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from rdf_utils.namespace import URL_SECORO_M
-from rdf_utils.models.vocab import URI_EXEC_PRED_HAS_CONFIG
-from bdd_dsl.models.namespace import PREFIX_TRANS
-from bdd_dsl.models.uri import (
-    URI_TRANS,
-    URI_MM_EVENT,
-    URI_MM_BT,
-    URI_MM_PY,
-)
-from bdd_dsl.models.urirefs import (
+from rdf_utils.models.vocab import (
     URI_AGN_PRED_HAS_AGN_MODEL,
     URI_AGN_PRED_OF_AGN,
     URI_AGN_TYPE_AGN,
     URI_AGN_TYPE_AGN_MODEL,
     URI_AGN_TYPE_MOD_AGN,
+    URI_ENV_PRED_HAS_OBJ_MODEL,
+    URI_ENV_PRED_OF_OBJ,
+    URI_ENV_TYPE_MOD_OBJ,
+    URI_ENV_TYPE_OBJ,
+    URI_ENV_TYPE_OBJ_MODEL,
+    URI_EXEC_PRED_HAS_CONFIG,
+)
+from rdf_utils.namespace import URL_SECORO_M
+
+from bdd_dsl.models.namespace import PREFIX_TRANS
+from bdd_dsl.models.uri import (
+    URI_MM_BT,
+    URI_MM_EVENT,
+    URI_MM_PY,
+    URI_TRANS,
+)
+from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_GIVEN,
     URI_BDD_PRED_HAS_AC,
     URI_BDD_PRED_HAS_SCENE,
@@ -23,20 +31,15 @@ from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_OF_TMPL,
     URI_BDD_PRED_THEN,
     URI_BDD_PRED_WHEN,
-    URI_BDD_TYPE_TASK_VAR,
-    URI_BHV_TYPE_BHV,
-    URI_ENV_PRED_OF_OBJ,
-    URI_ENV_TYPE_OBJ,
-    URI_ENV_PRED_HAS_OBJ_MODEL,
-    URI_ENV_TYPE_OBJ_MODEL,
-    URI_ENV_TYPE_MOD_OBJ,
-    URI_TASK_TYPE_TASK,
     URI_BDD_TYPE_SCENARIO,
     URI_BDD_TYPE_SCENARIO_TMPL,
     URI_BDD_TYPE_SCENARIO_VARIANT,
+    URI_BDD_TYPE_TASK_VAR,
     URI_BDD_TYPE_US,
     URI_BHV_PRED_OF_BHV,
+    URI_BHV_TYPE_BHV,
     URI_TASK_PRED_OF_TASK,
+    URI_TASK_TYPE_TASK,
 )
 
 # URLs to public queries

--- a/src/bdd_dsl/models/time_constraint.py
+++ b/src/bdd_dsl/models/time_constraint.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from rdflib import Graph, Literal, URIRef
 from rdf_utils.models.common import ModelBase
+from rdflib import Graph, Literal, URIRef
+
 from bdd_dsl.models.urirefs import (
     URI_TIME_PRED_AFTER_EVT,
     URI_TIME_PRED_BEFORE_EVT,
@@ -15,18 +16,18 @@ def process_time_constraint_model(constraint: ModelBase, graph: Graph) -> None:
     hrzn_secs = graph.value(subject=constraint.id, predicate=URI_TIME_PRED_HRZN_SEC, any=False)
     if isinstance(hrzn_secs, Literal):
         hrzn_float = hrzn_secs.toPython()
-        assert isinstance(
-            hrzn_float, float
-        ), f"Horizon seconds not a float ({type(hrzn_float)}): {hrzn_float}"
+        assert isinstance(hrzn_float, float), (
+            f"Horizon seconds not a float ({type(hrzn_float)}): {hrzn_float}"
+        )
         constraint.set_attr(key=URI_TIME_PRED_HRZN_SEC, val=hrzn_float)
 
     if URI_TIME_TYPE_BEFORE_EVT in constraint.types:
         before_evt_uri = graph.value(
             subject=constraint.id, predicate=URI_TIME_PRED_BEFORE_EVT, any=False
         )
-        assert isinstance(
-            before_evt_uri, URIRef
-        ), f"BeforeEvent TC '{constraint.id}' missing 'before-event' pred to URI: {before_evt_uri}"
+        assert isinstance(before_evt_uri, URIRef), (
+            f"BeforeEvent TC '{constraint.id}' missing 'before-event' pred to URI: {before_evt_uri}"
+        )
         constraint.set_attr(key=URI_TIME_PRED_BEFORE_EVT, val=before_evt_uri)
         return
 
@@ -34,9 +35,9 @@ def process_time_constraint_model(constraint: ModelBase, graph: Graph) -> None:
         after_evt_uri = graph.value(
             subject=constraint.id, predicate=URI_TIME_PRED_AFTER_EVT, any=False
         )
-        assert isinstance(
-            after_evt_uri, URIRef
-        ), f"AfterEvent TC '{constraint.id}' missing 'after-event' pred to URI: {after_evt_uri}"
+        assert isinstance(after_evt_uri, URIRef), (
+            f"AfterEvent TC '{constraint.id}' missing 'after-event' pred to URI: {after_evt_uri}"
+        )
         constraint.set_attr(key=URI_TIME_PRED_AFTER_EVT, val=after_evt_uri)
         return
 
@@ -44,17 +45,17 @@ def process_time_constraint_model(constraint: ModelBase, graph: Graph) -> None:
         before_evt_uri = graph.value(
             subject=constraint.id, predicate=URI_TIME_PRED_BEFORE_EVT, any=False
         )
-        assert isinstance(
-            before_evt_uri, URIRef
-        ), f"DuringEvents TC '{constraint.id}' missing 'before-event' pred to URI: {before_evt_uri}"
+        assert isinstance(before_evt_uri, URIRef), (
+            f"DuringEvents TC '{constraint.id}' missing 'before-event' pred to URI: {before_evt_uri}"
+        )
         constraint.set_attr(key=URI_TIME_PRED_BEFORE_EVT, val=before_evt_uri)
 
         after_evt_uri = graph.value(
             subject=constraint.id, predicate=URI_TIME_PRED_AFTER_EVT, any=False
         )
-        assert isinstance(
-            after_evt_uri, URIRef
-        ), f"DuringEvents TC '{constraint.id}' missing 'after-event' pred to URI: {after_evt_uri}"
+        assert isinstance(after_evt_uri, URIRef), (
+            f"DuringEvents TC '{constraint.id}' missing 'after-event' pred to URI: {after_evt_uri}"
+        )
         constraint.set_attr(key=URI_TIME_PRED_AFTER_EVT, val=after_evt_uri)
         return
 
@@ -67,27 +68,27 @@ def get_duration(constraint: ModelBase) -> dict:
     hrzn_secs = constraint.get_attr(key=URI_TIME_PRED_HRZN_SEC)
 
     if URI_TIME_TYPE_DURING in constraint.types:
-        assert (
-            isinstance(start_evt_uri, URIRef) and isinstance(end_evt_uri, URIRef)
-        ), f"DuringEvents '{constraint.id}' has invalid attrs: start={start_evt_uri}, end={end_evt_uri}"
+        assert isinstance(start_evt_uri, URIRef) and isinstance(end_evt_uri, URIRef), (
+            f"DuringEvents '{constraint.id}' has invalid attrs: start={start_evt_uri}, end={end_evt_uri}"
+        )
         return {
             URI_TIME_PRED_AFTER_EVT: start_evt_uri,
             URI_TIME_PRED_BEFORE_EVT: end_evt_uri,
         }
 
     if URI_TIME_TYPE_AFTER_EVT in constraint.types:
-        assert (
-            isinstance(start_evt_uri, URIRef) and isinstance(hrzn_secs, float)
-        ), f"AfterEvent '{constraint.id}' has invalid attrs: start={start_evt_uri}, horizon={hrzn_secs}"
+        assert isinstance(start_evt_uri, URIRef) and isinstance(hrzn_secs, float), (
+            f"AfterEvent '{constraint.id}' has invalid attrs: start={start_evt_uri}, horizon={hrzn_secs}"
+        )
         return {
             URI_TIME_PRED_AFTER_EVT: start_evt_uri,
             URI_TIME_PRED_HRZN_SEC: hrzn_secs,
         }
 
     if URI_TIME_TYPE_BEFORE_EVT in constraint.types:
-        assert (
-            isinstance(end_evt_uri, URIRef) and isinstance(hrzn_secs, float)
-        ), f"BeforeEvent '{constraint.id}' has invalid attrs: end={end_evt_uri}, horizon={hrzn_secs}"
+        assert isinstance(end_evt_uri, URIRef) and isinstance(hrzn_secs, float), (
+            f"BeforeEvent '{constraint.id}' has invalid attrs: end={end_evt_uri}, horizon={hrzn_secs}"
+        )
         return {
             URI_TIME_PRED_BEFORE_EVT: end_evt_uri,
             URI_TIME_PRED_HRZN_SEC: hrzn_secs,

--- a/src/bdd_dsl/models/urirefs.py
+++ b/src/bdd_dsl/models/urirefs.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from rdf_utils.namespace import (
-    NS_MM_ENV,
-    NS_MM_AGN,
-    NS_MM_TIME,
-)
+from rdf_utils.namespace import NS_MM_TIME
+
 from bdd_dsl.models.namespace import (
     NS_MM_BDD,
     NS_MM_BHV,
@@ -11,28 +8,6 @@ from bdd_dsl.models.namespace import (
     NS_MM_ROS,
     NS_MM_TASK,
 )
-
-# Environment
-URI_ENV_TYPE_OBJ = NS_MM_ENV["Object"]
-URI_ENV_TYPE_WS = NS_MM_ENV["Workspace"]
-URI_ENV_TYPE_WS_WS = NS_MM_ENV["WorkspaceHasWorkspace"]
-URI_ENV_TYPE_WS_OBJ = NS_MM_ENV["WorkspaceHasObject"]
-URI_ENV_TYPE_RIGID_OBJ = NS_MM_ENV["RigidObject"]
-URI_ENV_TYPE_MOD_OBJ = NS_MM_ENV["ModelledObject"]
-URI_ENV_TYPE_OBJ_MODEL = NS_MM_ENV["ObjectModel"]
-URI_ENV_PRED_HAS_OBJ_MODEL = NS_MM_ENV["has-object-model"]
-URI_ENV_PRED_HAS_OBJ = NS_MM_ENV["has-object"]
-URI_ENV_PRED_OF_OBJ = NS_MM_ENV["of-object"]
-URI_ENV_PRED_HAS_WS = NS_MM_ENV["has-workspace"]
-URI_ENV_PRED_OF_WS = NS_MM_ENV["of-workspace"]
-
-# Agent
-URI_AGN_TYPE_AGN = NS_MM_AGN["Agent"]
-URI_AGN_TYPE_MOD_AGN = NS_MM_AGN["ModelledAgent"]
-URI_AGN_TYPE_AGN_MODEL = NS_MM_AGN["AgentModel"]
-URI_AGN_PRED_OF_AGN = NS_MM_AGN["of-agent"]
-URI_AGN_PRED_HAS_AGN = NS_MM_AGN["has-agent"]
-URI_AGN_PRED_HAS_AGN_MODEL = NS_MM_AGN["has-agent-model"]
 
 # Behaviour
 URI_BHV_TYPE_BHV = NS_MM_BHV["Behaviour"]

--- a/src/bdd_dsl/models/user_story.py
+++ b/src/bdd_dsl/models/user_story.py
@@ -1,15 +1,20 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from typing import Any, Generator, Iterable, Optional
-from rdflib import RDF, Graph, URIRef, BNode
-from rdflib.query import ResultRow
-from rdf_utils.models.common import ModelBase, get_node_types
-from rdf_utils.namespace import URL_MM_PYTHON_SHACL, URL_SECORO_MM
+from collections.abc import Generator, Iterable
+from typing import Any
+
 from rdf_utils.constraints import check_shacl_constraints
-from bdd_dsl.models.environment import EnvModelLoader, ObjectModel, WorkspaceModel
+from rdf_utils.models.common import ModelBase, get_node_types
+from rdf_utils.models.vocab import (
+    URI_AGN_PRED_HAS_AGN,
+    URI_ENV_PRED_HAS_OBJ,
+    URI_ENV_PRED_HAS_WS,
+)
+from rdf_utils.namespace import URL_MM_PYTHON_SHACL, URL_SECORO_MM
+from rdflib import RDF, BNode, Graph, URIRef
+from rdflib.query import ResultRow
+
 from bdd_dsl.models.agent import AgentModel, AgnModelLoader
-from bdd_dsl.models.time_constraint import process_time_constraint_model
 from bdd_dsl.models.clauses import (
-    load_bhv_pickplace,
     DEFAULT_FLUENT_LOADERS,
     FluentClauseLoader,
     FluentClauseLoaderProtocol,
@@ -18,38 +23,37 @@ from bdd_dsl.models.clauses import (
     WhenBehaviourModel,
     WhenBhvLoader,
     WhenBhvLoaderProtocol,
+    load_bhv_pickplace,
 )
-from bdd_dsl.models.variation import TaskVariationModel
+from bdd_dsl.models.environment import EnvModelLoader, ObjectModel, WorkspaceModel
 from bdd_dsl.models.queries import Q_USER_STORY
+from bdd_dsl.models.time_constraint import process_time_constraint_model
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_GIVEN,
+    URI_BDD_PRED_HAS_AC,
+    URI_BDD_PRED_HAS_CLAUSE,
+    URI_BDD_PRED_HAS_SCENE,
     URI_BDD_PRED_HAS_VARIATION,
+    URI_BDD_PRED_IN_SET,
+    URI_BDD_PRED_OF_SCENARIO,
+    URI_BDD_PRED_OF_TMPL,
+    URI_BDD_PRED_REF_VAR,
     URI_BDD_PRED_THEN,
     URI_BDD_PRED_WHEN,
     URI_BDD_TYPE_CONFIG,
+    URI_BDD_TYPE_EXISTS,
+    URI_BDD_TYPE_FLUENT_CLAUSE,
+    URI_BDD_TYPE_FORALL,
     URI_BDD_TYPE_SCENARIO,
     URI_BDD_TYPE_SCENE_AGN,
     URI_BDD_TYPE_SCENE_OBJ,
-    URI_BDD_PRED_HAS_SCENE,
-    URI_BDD_PRED_OF_SCENARIO,
-    URI_BDD_PRED_OF_TMPL,
-    URI_BDD_PRED_HAS_AC,
     URI_BDD_TYPE_SCENE_WS,
     URI_BDD_TYPE_US,
     URI_BDD_TYPE_WHEN_BHV,
     URI_BHV_PRED_OF_BHV,
     URI_TASK_PRED_OF_TASK,
-    URI_ENV_PRED_HAS_OBJ,
-    URI_ENV_PRED_HAS_WS,
-    URI_AGN_PRED_HAS_AGN,
-    URI_BDD_PRED_HAS_CLAUSE,
-    URI_BDD_PRED_IN_SET,
-    URI_BDD_PRED_REF_VAR,
-    URI_BDD_TYPE_EXISTS,
-    URI_BDD_TYPE_FLUENT_CLAUSE,
-    URI_BDD_TYPE_FORALL,
 )
-
+from bdd_dsl.models.variation import TaskVariationModel
 
 BDD_SHACL_URLS = {
     f"{URL_SECORO_MM}/acceptance-criteria/bdd/bdd.shacl.ttl": "turtle",
@@ -177,7 +181,7 @@ class SceneModel(ModelBase):
     def has_invariant_elem(self, elem_id: URIRef) -> bool:
         return elem_id in self.objects or elem_id in self.workspaces or elem_id in self.agents
 
-    def get_variable_elems_re(self, var_val: Any, var_elems: Optional[set[URIRef]] = None) -> None:
+    def get_variable_elems_re(self, var_val: Any, var_elems: set[URIRef] | None = None) -> None:
         if var_elems is None:
             var_elems = set()
 
@@ -194,10 +198,10 @@ class SceneModel(ModelBase):
 
 
 class IHasClause(ModelBase):
-    _forall_id: Optional[URIRef]
-    _when_bhv_id: Optional[URIRef]
+    _forall_id: URIRef | None
+    _when_bhv_id: URIRef | None
     _fluent_loader: FluentClauseLoader
-    _bhv_loader: Optional[WhenBhvLoader]
+    _bhv_loader: WhenBhvLoader | None
     exists_clauses: set[URIRef]
     clauses: dict[URIRef, IClause]
     _path_to_clauses: dict[URIRef, URIRef | None]
@@ -210,9 +214,9 @@ class IHasClause(ModelBase):
         node_id: URIRef,
         scenario: ScenarioModel,
         fluent_loader: FluentClauseLoader,
-        bhv_loader: Optional[WhenBhvLoader] = None,
-        graph: Optional[Graph] = None,
-        types: Optional[set[URIRef]] = None,
+        bhv_loader: WhenBhvLoader | None = None,
+        graph: Graph | None = None,
+        types: set[URIRef] | None = None,
     ) -> None:
         super().__init__(node_id=node_id, graph=graph, types=types)
         self.variables = set()
@@ -360,7 +364,7 @@ class IHasClause(ModelBase):
             elif isinstance(fc, IHasClause):
                 yield from fc.fluent_clauses()
             else:
-                raise ValueError(f"Unexpected clause type ({type(fc)}): {fc}")
+                raise TypeError(f"Unexpected clause type ({type(fc)}): {fc}")
 
     def config_clauses(self) -> Generator[FluentClauseModel, None, None]:
         for fc in self.fluent_clauses():
@@ -380,7 +384,7 @@ class ForAllModel(IHasClause, IClause):
         graph: Graph,
         fluent_loader: FluentClauseLoader,
         bhv_loader: WhenBhvLoader,
-        types: Optional[set[URIRef]] = None,
+        types: set[URIRef] | None = None,
     ) -> None:
         IHasClause.__init__(
             self,
@@ -433,7 +437,7 @@ class ThereExistsModel(IHasClause, IClause):
         scenario: ScenarioModel,
         fluent_loader: FluentClauseLoader,
         graph: Graph,
-        types: Optional[set[URIRef]] = None,
+        types: set[URIRef] | None = None,
     ) -> None:
         IHasClause.__init__(
             self,
@@ -471,17 +475,20 @@ class ScenarioVariantModel(IHasClause):
         us_graph: Graph,
         full_graph: Graph,
         var_id: URIRef,
-        fluent_loaders: dict[URIRef, FluentClauseLoaderProtocol] = DEFAULT_FLUENT_LOADERS,
-        bhv_loaders: list[WhenBhvLoaderProtocol] = [load_bhv_pickplace],
+        fluent_loaders: dict[URIRef, FluentClauseLoaderProtocol] | None = None,
+        bhv_loaders: list[WhenBhvLoaderProtocol] | None = None,
     ) -> None:
         node_val = us_graph.value(subject=var_id, predicate=URI_BDD_PRED_OF_SCENARIO)
-        assert node_val is not None and isinstance(node_val, URIRef), (
-            f"ScenarioVariant '{var_id}' does not refer to a Scenario"
-        )
+        if not isinstance(node_val, URIRef):
+            raise TypeError(f"ScenarioVariant '{var_id}' does not link to a Scenario URI")
         scenario_id = node_val
 
         scenario = ScenarioModel(scenario_id=scenario_id, graph=us_graph)
+        if fluent_loaders is None:
+            fluent_loaders = DEFAULT_FLUENT_LOADERS
         fc_loader = FluentClauseLoader(loaders=fluent_loaders)
+        if bhv_loaders is None:
+            bhv_loaders = [load_bhv_pickplace]
         bhv_loader = WhenBhvLoader(loaders=bhv_loaders)
         super().__init__(
             node_id=var_id,
@@ -551,7 +558,7 @@ class ScenarioVariantModel(IHasClause):
         return whn_bhv
 
 
-class UserStoryLoader(object):
+class UserStoryLoader:
     def __init__(self, graph: Graph, shacl_check=True, quiet=False) -> None:
         if shacl_check:
             check_shacl_constraints(graph=graph, shacl_dict=BDD_SHACL_URLS, quiet=quiet)

--- a/src/bdd_dsl/models/variation.py
+++ b/src/bdd_dsl/models/variation.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from typing import Any, Iterable, Iterator, Optional
 import itertools
-from rdflib import BNode, Graph, URIRef, Literal
+from collections.abc import Iterable, Iterator
+from typing import Any
+
 from rdf_utils.collection import load_list_re
 from rdf_utils.models.common import ModelBase, get_node_types
+from rdflib import BNode, Graph, Literal, URIRef
+
 from bdd_dsl.models.namespace import NS_MM_BDD
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_ELEMS,
@@ -16,7 +19,6 @@ from bdd_dsl.models.urirefs import (
     URI_TASK_PRED_OF_TASK,
 )
 
-
 URI_BDD_TYPE_COMBINATION = NS_MM_BDD["Combination"]
 URI_BDD_TYPE_PERMUTATION = NS_MM_BDD["Permutation"]
 URI_BDD_PRED_FROM = NS_MM_BDD["from"]
@@ -24,15 +26,12 @@ URI_BDD_PRED_REP_ALLOWED = NS_MM_BDD["repetition-allowed"]
 URI_BDD_PRED_LENGTH = NS_MM_BDD["length"]
 
 
-def try_get_const_set_elems(graph: Graph, set_id: URIRef) -> Optional[list]:
+def try_get_const_set_elems(graph: Graph, set_id: URIRef) -> list | None:
     sets_data_types = get_node_types(graph=graph, node_id=set_id)
     if URI_BDD_TYPE_CONST_SET not in sets_data_types:
         return None
 
-    elem_list = []
-    for elem in graph.objects(subject=set_id, predicate=URI_BDD_PRED_ELEMS):
-        elem_list.append(elem)
-    return elem_list
+    return list(graph.objects(subject=set_id, predicate=URI_BDD_PRED_ELEMS))
 
 
 class SetEnumerationModel(ModelBase):
@@ -74,9 +73,7 @@ class SetEnumerationModel(ModelBase):
         assert URI_BDD_TYPE_CONST_SET in set_model.types, (
             f"type(s) not handled for Set {set_model.id}: {set_model.types}"
         )
-        from_list = []
-        for elem in graph.objects(subject=set_model.id, predicate=URI_BDD_PRED_ELEMS):
-            from_list.append(elem)
+        from_list = list(graph.objects(subject=set_model.id, predicate=URI_BDD_PRED_ELEMS))
         self.set_attr(key=URI_BDD_PRED_FROM, val=from_list)
 
         # if no length specified, set to length of list
@@ -253,7 +250,7 @@ def get_task_variations(task_var: TaskVariationModel) -> tuple[list[URIRef], lis
                 # list
                 uri_iterables.append(set_data)
             else:
-                raise RuntimeError(
+                raise TypeError(
                     f"TaskVariation {task_var.id}: sets for cartesian product not list or URIRef: {set_data}"
                 )
 

--- a/src/bdd_dsl/representation.py
+++ b/src/bdd_dsl/representation.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
+from collections.abc import Iterable
 from numbers import Number
-from typing import Any, Iterable, Optional, Protocol
+from typing import Any, Protocol
+
 from rdf_utils.models.common import ModelBase
 from rdflib import URIRef
 from rdflib.namespace import NamespaceManager
@@ -44,7 +46,7 @@ def get_clause_role_rep(scenario: ScenarioModel, clause: IClause) -> str:
     raise ValueError(f"Role '{clause.clause_of}' is not Given/When/Then of '{scenario.id}'")
 
 
-def var_val_to_str(var_val: Any, ns_manager: Optional[NamespaceManager] = None) -> str:
+def var_val_to_str(var_val: Any, ns_manager: NamespaceManager | None = None) -> str:
     if isinstance(var_val, URIRef):
         return var_val.n3(namespace_manager=ns_manager)
 
@@ -69,7 +71,7 @@ def get_model_rep(
     model: ModelBase,
     tmpl_str: str,
     attr_mappings: dict[URIRef, str],
-    ns_manager: Optional[NamespaceManager] = None,
+    ns_manager: NamespaceManager | None = None,
 ) -> str:
     subs = {}
     for attr_uri, sub_key in attr_mappings.items():
@@ -92,13 +94,13 @@ class ModelToStrProtocol(Protocol):
     """
 
     def __call__(
-        self, model: ModelBase, ns_manager: Optional[NamespaceManager], **kwargs: Any
-    ) -> Optional[str]: ...
+        self, model: ModelBase, ns_manager: NamespaceManager | None, **kwargs: Any
+    ) -> str | None: ...
 
 
 def get_str_tc_before_event(
-    model: ModelBase, ns_manager: Optional[NamespaceManager], **kwargs: Any
-) -> Optional[str]:
+    model: ModelBase, ns_manager: NamespaceManager | None, **kwargs: Any
+) -> str | None:
     if URI_TIME_TYPE_BEFORE_EVT not in model.types:
         return None
 
@@ -111,8 +113,8 @@ def get_str_tc_before_event(
 
 
 def get_str_tc_after_event(
-    model: ModelBase, ns_manager: Optional[NamespaceManager], **kwargs: Any
-) -> Optional[str]:
+    model: ModelBase, ns_manager: NamespaceManager | None, **kwargs: Any
+) -> str | None:
     if URI_TIME_TYPE_AFTER_EVT not in model.types:
         return None
 
@@ -125,8 +127,8 @@ def get_str_tc_after_event(
 
 
 def get_str_tc_during_events(
-    model: ModelBase, ns_manager: Optional[NamespaceManager], **kwargs: Any
-) -> Optional[str]:
+    model: ModelBase, ns_manager: NamespaceManager | None, **kwargs: Any
+) -> str | None:
     if URI_TIME_TYPE_DURING not in model.types:
         return None
 
@@ -156,7 +158,7 @@ class VariableStrTemplate:
             raise ValueError(f"VariableStrTemplate: invalid mappings for '{self.tmpl_str}': {e}")
 
     def render(
-        self, var_values: dict[URIRef, Any], ns_manager: Optional[NamespaceManager] = None
+        self, var_values: dict[URIRef, Any], ns_manager: NamespaceManager | None = None
     ) -> str:
         subs = {}
         for uri, uri_map in self.var_map.items():
@@ -174,7 +176,7 @@ class VarTmplCreatorProtocol(Protocol):
     Should return None if model is invalid, e.g., wrong types.
     """
 
-    def __call__(self, model: ModelBase, **kwargs: Any) -> Optional[VariableStrTemplate]: ...
+    def __call__(self, model: ModelBase, **kwargs: Any) -> VariableStrTemplate | None: ...
 
 
 class ClauseRepBuilder:
@@ -196,7 +198,7 @@ class ClauseRepBuilder:
         role: str,
         clause: FluentClauseModel,
         val_dict: dict[URIRef, Any],
-        ns_manager: Optional[NamespaceManager],
+        ns_manager: NamespaceManager | None,
     ) -> str:
         clause_rep = self._render_var_clause(
             clause=clause, val_dict=val_dict, ns_manager=ns_manager
@@ -208,7 +210,7 @@ class ClauseRepBuilder:
         self,
         clause: WhenBehaviourModel,
         val_dict: dict[URIRef, Any],
-        ns_manager: Optional[NamespaceManager],
+        ns_manager: NamespaceManager | None,
     ) -> str:
         clause_rep = self._render_var_clause(
             clause=clause, val_dict=val_dict, ns_manager=ns_manager
@@ -219,7 +221,7 @@ class ClauseRepBuilder:
         self,
         clause: FluentClauseModel | WhenBehaviourModel,
         val_dict: dict[URIRef, Any],
-        ns_manager: Optional[NamespaceManager],
+        ns_manager: NamespaceManager | None,
     ) -> str:
         if clause.id not in self._clause_templates:
             for tmpl_crtr in self._clause_tmpl_creators:
@@ -239,7 +241,7 @@ class ClauseRepBuilder:
     def _render_tc(
         self,
         clause: FluentClauseModel | WhenBehaviourModel,
-        ns_manager: Optional[NamespaceManager],
+        ns_manager: NamespaceManager | None,
     ) -> str:
 
         # Render time constraint
@@ -264,7 +266,7 @@ class ScenarioVariantRep:
         scr_var: ScenarioVariantModel,
         clause_rep_builder: ClauseRepBuilder,
         val_dict: dict[URIRef, Any],
-        ns_manager: Optional[NamespaceManager] = None,
+        ns_manager: NamespaceManager | None = None,
     ) -> None:
         self.variant_rep = scr_var.id.n3(ns_manager)
         self.bhv_rep = clause_rep_builder.render_when_bhv_clause(
@@ -293,7 +295,7 @@ class ScenarioVariantRep:
         return self._clause_reps[clause_id]
 
 
-def get_tmpl_bhv_pickplace(model: ModelBase, **kwargs) -> Optional[VariableStrTemplate]:
+def get_tmpl_bhv_pickplace(model: ModelBase, **kwargs) -> VariableStrTemplate | None:
     if not isinstance(model, WhenBehaviourModel):
         return None
 
@@ -348,7 +350,7 @@ def get_tmpl_bhv_pickplace(model: ModelBase, **kwargs) -> Optional[VariableStrTe
     )
 
 
-def get_tmpl_fc_located_at(model: ModelBase, **kwargs) -> Optional[VariableStrTemplate]:
+def get_tmpl_fc_located_at(model: ModelBase, **kwargs) -> VariableStrTemplate | None:
     if not isinstance(model, FluentClauseModel):
         return None
 
@@ -377,7 +379,7 @@ def get_tmpl_fc_located_at(model: ModelBase, **kwargs) -> Optional[VariableStrTe
     )
 
 
-def get_tmpl_fc_is_held(model: ModelBase, **kwargs) -> Optional[VariableStrTemplate]:
+def get_tmpl_fc_is_held(model: ModelBase, **kwargs) -> VariableStrTemplate | None:
     if not isinstance(model, FluentClauseModel):
         return None
 
@@ -405,7 +407,7 @@ def get_tmpl_fc_is_held(model: ModelBase, **kwargs) -> Optional[VariableStrTempl
     )
 
 
-def get_tmpl_fc_config(model: ModelBase, **kwargs) -> Optional[VariableStrTemplate]:
+def get_tmpl_fc_config(model: ModelBase, **kwargs) -> VariableStrTemplate | None:
     if not isinstance(model, FluentClauseModel):
         return None
 
@@ -432,7 +434,7 @@ def get_tmpl_fc_config(model: ModelBase, **kwargs) -> Optional[VariableStrTempla
     )
 
 
-def get_tmpl_fc_str_tmpl(model: ModelBase, **kwargs) -> Optional[VariableStrTemplate]:
+def get_tmpl_fc_str_tmpl(model: ModelBase, **kwargs) -> VariableStrTemplate | None:
     if not isinstance(model, FluentClauseModel):
         return None
 

--- a/src/bdd_dsl/utils/common.py
+++ b/src/bdd_dsl/utils/common.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from bdd_dsl.exception import GracefulExit
 
-
 BDD_DSL_VERSION = version("bdd-dsl")
 
 
@@ -14,7 +13,9 @@ def raise_graceful_exit_handler(signum, frame):
     raise GracefulExit(signum)
 
 
-def register_termination_signals(handled_signals=[signal.SIGINT, signal.SIGTERM]):
+def register_termination_signals(handled_signals=None):
+    if handled_signals is None:
+        handled_signals = [signal.SIGINT, signal.SIGTERM]
     for signum in handled_signals:
         signal.signal(signum, raise_graceful_exit_handler)
 
@@ -23,7 +24,7 @@ def check_or_convert_ndarray(in_array) -> np.ndarray:
     if isinstance(in_array, np.ndarray):
         return in_array
 
-    if isinstance(in_array, list) or isinstance(in_array, tuple):
+    if isinstance(in_array, (list, tuple)):
         return np.array(in_array)
 
     raise ValueError(

--- a/src/bdd_dsl/utils/jinja.py
+++ b/src/bdd_dsl/utils/jinja.py
@@ -1,30 +1,33 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from typing import Any, Iterable, Optional, Protocol
+from collections.abc import Iterable
+from typing import Any, Protocol
+
 from jinja2 import Environment, FileSystemLoader, Template
+from rdf_utils.caching import read_file_and_cache, read_url_and_cache
 from rdflib import Graph, URIRef
 from rdflib.namespace import NamespaceManager
-from rdf_utils.caching import read_file_and_cache, read_url_and_cache
+
 from bdd_dsl.models.clauses import (
     FluentClauseModel,
     WhenBehaviourModel,
 )
 from bdd_dsl.models.frames import (
     FR_AGENTS,
-    FR_OBJECTS,
-    FR_NAME,
     FR_CRITERIA,
+    FR_NAME,
+    FR_OBJECTS,
     FR_VARIATIONS,
     FR_WS,
 )
 from bdd_dsl.models.urirefs import (
-    URI_BDD_TYPE_CONFIG,
-    URI_BDD_TYPE_MOVE_SAFE,
-    URI_BDD_TYPE_SORTED,
     URI_BDD_PRED_REF_AGN,
     URI_BDD_PRED_REF_OBJ,
     URI_BDD_PRED_REF_WS,
+    URI_BDD_TYPE_CONFIG,
     URI_BDD_TYPE_IS_HELD,
     URI_BDD_TYPE_LOCATED_AT,
+    URI_BDD_TYPE_MOVE_SAFE,
+    URI_BDD_TYPE_SORTED,
     URI_BDD_TYPE_STR_TMPL,
     URI_TIME_TYPE_AFTER_EVT,
     URI_TIME_TYPE_BEFORE_EVT,
@@ -200,7 +203,7 @@ def get_bhv_str_pickplace(
     return tmpl.render(var_values=var_values, ns_manager=ns_manager)
 
 
-class GherkinClauseStrGen(object):
+class GherkinClauseStrGen:
     _tc_str_gens: dict[URIRef, ModelToStrProtocol]
     _fc_str_gens: dict[URIRef, FluentClauseToStringProtocol]
     _wb_str_gens: list[WhenBhvToStringProtocol]
@@ -279,15 +282,15 @@ def get_gherkin_clauses_re(
             exists_set = var_values[exists_model.in_set]
             if isinstance(exists_set, str):
                 # will also raise for URIRef
-                raise ValueError(
+                raise TypeError(
                     f"ThereExists '{exists_model.id}': expected a set of value, got ({type(exists_set)}): {exists_set}"
                 )
             elif not isinstance(exists_set, Iterable):
-                raise ValueError(
+                raise TypeError(
                     f"ThereExists '{exists_model.id}': value 'in-set' not an Iterable: {exists_set}"
                 )
         else:
-            raise RuntimeError(
+            raise TypeError(
                 f"ThereExists '{exists_model.id}': unhandled type for 'in-set': {exists_model.in_set}"
             )
         exists_str_set = []
@@ -340,7 +343,7 @@ def get_gherkin_clauses_re(
                     f"ForAll '{w_clause.id}': value 'in-set' not an Iterable: {forall_set}"
                 )
             else:
-                raise RuntimeError(
+                raise TypeError(
                     f"ForAll '{w_clause.id}': unhandled type for 'in-set': {w_clause.in_set}"
                 )
 
@@ -448,12 +451,14 @@ def prepare_scenario_variant_data(
 def prepare_jinja2_template_data(
     us_loader: UserStoryLoader,
     full_graph: Graph,
-    ns_manager: Optional[NamespaceManager] = None,
+    ns_manager: NamespaceManager | None = None,
     tc_str_gens: dict[URIRef, ModelToStrProtocol] = DEFAULT_TIME_CSTR_STR_GENS,
     fc_str_gens: dict[URIRef, FluentClauseToStringProtocol] = DEFAULT_FLUENT_CLAUSE_STR_GENS,
-    wb_str_gens: list[WhenBhvToStringProtocol] = [get_bhv_str_pickplace],
+    wb_str_gens: list[WhenBhvToStringProtocol] | None = None,
 ) -> list[dict]:
     """TODO(minhnh): specify which template"""
+    if wb_str_gens is None:
+        wb_str_gens = [get_bhv_str_pickplace]
     if ns_manager is None:
         ns_manager = full_graph.namespace_manager
 

--- a/src/bdd_dsl/utils/json.py
+++ b/src/bdd_dsl/utils/json.py
@@ -1,36 +1,37 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from importlib import import_module
-from typing import List, Optional, Tuple, Type
-from socket import _GLOBAL_DEFAULT_TIMEOUT
 import json
-from pyld import jsonld
+from importlib import import_module
+from socket import _GLOBAL_DEFAULT_TIMEOUT
+
 import py_trees as pt
 import rdflib
+from pyld import jsonld
 from rdf_utils.caching import read_file_and_cache, read_url_and_cache
+
 from bdd_dsl.behaviours.actions import ActionWithEvents
 from bdd_dsl.events.event_handler import EventHandler, SimpleEventLoop
-from bdd_dsl.models.queries import (
-    EVENT_LOOP_QUERY,
-    BEHAVIOUR_TREE_QUERY,
-    Q_BT_SEQUENCE,
-    Q_BT_PARALLEL,
-)
 from bdd_dsl.models.frames import (
-    EVENT_LOOP_FRAME,
     BEHAVIOUR_TREE_FRAME,
-    FR_NAME,
-    FR_DATA,
-    FR_EVENTS,
-    FR_SUBTREE,
-    FR_TYPE,
+    EVENT_LOOP_FRAME,
     FR_CHILDREN,
-    FR_START_E,
+    FR_DATA,
+    FR_EL,
     FR_END_E,
-    FR_IMPL_MODULE,
-    FR_IMPL_CLASS,
+    FR_EVENTS,
     FR_IMPL_ARG_NAMES,
     FR_IMPL_ARG_VALS,
-    FR_EL,
+    FR_IMPL_CLASS,
+    FR_IMPL_MODULE,
+    FR_NAME,
+    FR_START_E,
+    FR_SUBTREE,
+    FR_TYPE,
+)
+from bdd_dsl.models.queries import (
+    BEHAVIOUR_TREE_QUERY,
+    EVENT_LOOP_QUERY,
+    Q_BT_PARALLEL,
+    Q_BT_SEQUENCE,
 )
 
 
@@ -81,12 +82,12 @@ def get_type_set(data: dict) -> set:
         for t in data_types:
             data_types_set.add(t)
     else:
-        raise RuntimeError(f"unexpected type for '{FR_TYPE}' field: {type(data[FR_TYPE])}")
+        raise TypeError(f"unexpected type for '{FR_TYPE}' field: {type(data[FR_TYPE])}")
     return data_types_set
 
 
 def create_event_handler_from_data(
-    el_data: dict, e_handler_cls: Type[EventHandler], e_handler_kwargs: dict
+    el_data: dict, e_handler_cls: type[EventHandler], e_handler_kwargs: dict
 ) -> EventHandler:
     """Create an event handler object from framed, dictionary-like data.
 
@@ -97,7 +98,7 @@ def create_event_handler_from_data(
 
 
 def create_event_handler_from_graph(
-    graph: rdflib.Graph, e_handler_cls: Type[EventHandler], e_handler_kwargs: dict
+    graph: rdflib.Graph, e_handler_cls: type[EventHandler], e_handler_kwargs: dict
 ) -> list:
     model = query_graph(graph, EVENT_LOOP_QUERY)
     framed_model = jsonld.frame(model, EVENT_LOOP_FRAME)
@@ -129,7 +130,7 @@ def load_python_event_action(node_data: dict, event_handler: EventHandler):
 
     action_cls = getattr(import_module(node_data[FR_IMPL_MODULE]), node_data[FR_IMPL_CLASS])
     if not issubclass(action_cls, ActionWithEvents):
-        raise ValueError(
+        raise TypeError(
             f"'{action_cls.__name__}' is not a subclass of '{ActionWithEvents.__name__}'"
         )
 
@@ -137,9 +138,9 @@ def load_python_event_action(node_data: dict, event_handler: EventHandler):
     if FR_IMPL_ARG_NAMES in node_data and FR_IMPL_ARG_VALS in node_data:
         kwarg_names = node_data[FR_IMPL_ARG_NAMES]
         kwarg_vals = node_data[FR_IMPL_ARG_VALS]
-        if not isinstance(kwarg_names, List):
+        if not isinstance(kwarg_names, list):
             kwarg_names = [kwarg_names]
-        if not isinstance(kwarg_vals, List):
+        if not isinstance(kwarg_vals, list):
             kwarg_vals = [kwarg_vals]
 
         if len(kwarg_names) != len(kwarg_vals):
@@ -183,14 +184,14 @@ def create_subtree_behaviours(
 
 
 def get_bt_event_data_from_graph(
-    graph: rdflib.Graph, bt_root_name: Optional[str] = None
-) -> List[tuple]:
+    graph: rdflib.Graph, bt_root_name: str | None = None
+) -> list[tuple]:
     bt_model = query_graph(graph, BEHAVIOUR_TREE_QUERY)
     bt_model_framed = jsonld.frame(bt_model, BEHAVIOUR_TREE_FRAME)
 
-    assert isinstance(
-        bt_model_framed, dict
-    ), f"unexpected type for framed model: {type(bt_model_framed)}"
+    assert isinstance(bt_model_framed, dict), (
+        f"unexpected type for framed model: {type(bt_model_framed)}"
+    )
 
     if FR_DATA not in bt_model_framed:
         if bt_root_name is not None and bt_model_framed[FR_NAME] != bt_root_name:
@@ -211,9 +212,11 @@ def get_bt_event_data_from_graph(
 def create_bt_from_graph(
     graph: rdflib.Graph,
     bt_name: str,
-    e_handler_cls: Type[EventHandler] = SimpleEventLoop,
-    e_handler_kwargs: dict = {},
-) -> List[Tuple]:
+    e_handler_cls: type[EventHandler] = SimpleEventLoop,
+    e_handler_kwargs: dict | None = None,
+) -> list[tuple]:
+    if e_handler_kwargs is None:
+        e_handler_kwargs = {}
     e_data_and_bts = get_bt_event_data_from_graph(graph, bt_name)
 
     # multiple BT roots

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -1,26 +1,27 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 import unittest
 from urllib.request import HTTPError
-from rdflib import Dataset
-from rdf_utils.namespace import URL_SECORO_M, URL_MM_PYTHON_SHACL
+
+from rdf_utils.constraints import check_shacl_constraints
+from rdf_utils.models.execution import load_attr_path
 from rdf_utils.models.python import (
-    URI_PY_TYPE_MODULE_ATTR,
     URI_PY_PRED_ATTR_NAME,
     URI_PY_PRED_MODULE_NAME,
+    URI_PY_TYPE_MODULE_ATTR,
     load_py_module_attr,
 )
-from rdf_utils.models.execution import load_attr_path
+from rdf_utils.models.vocab import URI_EXEC_PRED_PATH, URI_EXEC_TYPE_SYS_RES
+from rdf_utils.namespace import URL_MM_PYTHON_SHACL, URL_SECORO_M
 from rdf_utils.resolver import install_resolver
-from rdf_utils.constraints import check_shacl_constraints
+from rdflib import Dataset
+
 from bdd_dsl.execution.common import (
     URL_MM_EXEC_SHACL,
     load_attr_has_config,
 )
 from bdd_dsl.models.agent import AgentModel
 from bdd_dsl.models.environment import ObjectModel
-from rdf_utils.models.vocab import URI_EXEC_PRED_PATH, URI_EXEC_TYPE_SYS_RES
 from bdd_dsl.models.user_story import UserStoryLoader
-
 
 SPEC_MODEL_URLS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/environments/secorolab.env.json": "json-ld",

--- a/tests/test_bdd_spec.py
+++ b/tests/test_bdd_spec.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 import unittest
+
 import rdflib
-from rdf_utils.resolver import install_resolver
 from rdf_utils.namespace import URL_SECORO_M
-from bdd_dsl.models.user_story import UserStoryLoader
+from rdf_utils.resolver import install_resolver
+
 from bdd_dsl.models.frames import FR_CRITERIA, FR_VARIATIONS
+from bdd_dsl.models.user_story import UserStoryLoader
 from bdd_dsl.utils.jinja import prepare_jinja2_template_data
 
 MODEL_URLS = {

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from os.path import join, dirname
 import unittest
+from os.path import dirname, join
+
 import rdflib
 from py_trees.trees import BehaviourTree
+
 from bdd_dsl.events.event_handler import SimpleEventLoop
 from bdd_dsl.utils.json import (
-    create_event_handler_from_graph,
     create_bt_from_graph,
+    create_event_handler_from_graph,
 )
-
 
 PKG_ROOT = join(dirname(__file__), "..")
 META_MODELs_PATH = join(PKG_ROOT, "metamodels")


### PR DESCRIPTION
- This migrates `URIRef`'s definitions for environment and agent matching minhnh/rdf-utils#28.
- Additional fix all issues with stricter Ruff v0.16.