### PR TITLE
Adapts  to model storing mechanism for scene elements in scene-dsl

### DIFF
--- a/examples/generate_bdd_specs.py
+++ b/examples/generate_bdd_specs.py
@@ -5,9 +5,9 @@ from timeit import default_timer as timer
 from urllib.request import HTTPError
 
 import rdflib
+from rdf_utils.namespace import URL_SECORO_M
 from rdf_utils.naming import get_valid_filename
 from rdf_utils.resolver import install_resolver
-from rdf_utils.uri import URL_SECORO_M
 
 from bdd_dsl.models.frames import FR_NAME
 from bdd_dsl.models.user_story import UserStoryLoader

--- a/examples/generated/environment.py
+++ b/examples/generated/environment.py
@@ -6,8 +6,8 @@ from urllib.error import HTTPError
 
 from behave.model import Step
 from behave.runner import Context
+from rdf_utils.namespace import URL_SECORO_M
 from rdf_utils.resolver import install_resolver
-from rdf_utils.uri import URL_SECORO_M
 from rdflib import Dataset
 
 from bdd_dsl.execution.mockup import before_all_mockup, before_scenario

--- a/src/bdd_dsl/behave.py
+++ b/src/bdd_dsl/behave.py
@@ -5,13 +5,13 @@ from enum import Enum
 from typing import Any
 
 from behave.model import Table
+from rdf_utils.models.common import ModelBase
 from rdf_utils.uri import try_parse_n3_iterable, try_parse_n3_string
-from rdflib import Graph
+from rdflib import Graph, URIRef
 from rdflib.namespace import NamespaceManager
 from rdflib.term import Node as RDFNode
-from scene_dsl.rdf_parser.agent import AgentModel
-from scene_dsl.rdf_parser.environment import ObjectModel, WorkspaceModel
-from scene_dsl.rdf_parser.scene import SceneModel
+from scene_dsl.rdf_parser.scene import SceneModel, WorkspaceModel
+from scene_dsl.rdf_parser.scenex import SceneInstanceModel
 
 PARAM_OBJ = "obj_str"
 PARAM_WS = "ws_str"
@@ -36,13 +36,9 @@ CLAUSE_BHV_PICK = f'"{{{PARAM_AGN}}}" picks "{{{PARAM_OBJ}}}"'
 CLAUSE_BHV_PLACE = f'"{{{PARAM_AGN}}}" places "{{{PARAM_OBJ}}}" at "{{{PARAM_WS}}}"'
 
 
-def load_obj_models_from_table(
-    table: Table, graph: Graph, scene: SceneModel
-) -> Generator[ObjectModel, None, None]:
-    """
-    Load ObjectModel instances from a table of URIs in the behave Context,
-    designed for the 'Given a set of objects' clause
-    """
+def load_obj_resources_from_table(
+    table: Table, graph: Graph, scene_inst: SceneInstanceModel
+) -> Generator[tuple[URIRef, dict[URIRef, ModelBase]], None, None]:
     for row in table:
         obj_id_str = row["name"]
         try:
@@ -50,16 +46,12 @@ def load_obj_models_from_table(
         except ValueError as e:
             raise RuntimeError(f"can't parse object URI '{obj_id_str}': {e}")
 
-        yield scene.load_obj_model(obj_id=obj_uri, graph=graph)
+        yield obj_uri, scene_inst.object_models.get(obj_uri, {})
 
 
-def load_agn_models_from_table(
-    table: Table, graph: Graph, scene: SceneModel
-) -> Generator[AgentModel, None, None]:
-    """
-    Load AgentModel instances from a table of URIs in the behave Context,
-    designed for the 'Given a set of agents' clause
-    """
+def load_agn_resources_from_table(
+    table: Table, graph: Graph, scene_inst: SceneInstanceModel
+) -> Generator[tuple[URIRef, dict[URIRef, ModelBase]], None, None]:
     for row in table:
         agn_id_str = row["name"]
         try:
@@ -67,7 +59,7 @@ def load_agn_models_from_table(
         except ValueError as e:
             raise RuntimeError(f"can't parse agent URI '{agn_id_str}': {e}")
 
-        yield scene.load_agn_model(agent_id=agn_uri, graph=graph)
+        yield agn_uri, scene_inst.agent_models.get(agn_uri, {})
 
 
 def load_ws_models_from_table(
@@ -80,7 +72,9 @@ def load_ws_models_from_table(
         except ValueError as e:
             raise RuntimeError(f"can't parse workspace URI '{ws_id_str}': {e}")
 
-        yield scene.load_ws_model(ws_id=ws_uri, graph=graph)
+        if ws_uri not in scene.workspaces:
+            raise ValueError(f"workspace '{ws_uri}' is not in scene '{scene.id}'")
+        yield scene.workspaces[ws_uri]
 
 
 class ParamType(Enum):

--- a/src/bdd_dsl/execution/mockup.py
+++ b/src/bdd_dsl/execution/mockup.py
@@ -118,8 +118,7 @@ def given_workspaces_mockup(context: Context):
     for ws_model in load_ws_models_from_table(
         table=context.table, graph=context.model_graph, scene=context.current_scenario.scene
     ):
-        element_loader = context.current_scenario.scene.element_loader
-        for obj_model in element_loader.load_ws_objects(
+        for obj_model in context.current_scenario.scene.load_ws_objects(
             graph=context.model_graph, ws_id=ws_model.id
         ):
             if URI_PY_TYPE_MODULE_ATTR in obj_model.model_types:

--- a/src/bdd_dsl/execution/mockup.py
+++ b/src/bdd_dsl/execution/mockup.py
@@ -4,8 +4,7 @@ from typing import Any
 
 from behave.model import Scenario
 from behave.runner import Context
-from rdf_utils.models.common import ModelLoader, URIRef
-from rdf_utils.models.execution import load_attr_path
+from rdf_utils.models.common import ModelBase, URIRef
 from rdf_utils.models.python import (
     URI_PY_PRED_ATTR_NAME,
     URI_PY_PRED_MODULE_NAME,
@@ -15,6 +14,7 @@ from rdf_utils.models.python import (
 from rdf_utils.models.vocab import URI_EXEC_PRED_PATH, URI_EXEC_TYPE_RES_PATH
 from rdf_utils.uri import NamespaceManager, try_expand_curie
 from rdflib import Graph
+from scene_dsl.rdf_parser.scenex import SceneInstanceModel
 
 from bdd_dsl.behave import (
     PARAM_AGN,
@@ -23,14 +23,14 @@ from bdd_dsl.behave import (
     PARAM_OBJ,
     PARAM_UNTIL_EVT,
     PARAM_WS,
-    load_agn_models_from_table,
-    load_obj_models_from_table,
+    load_agn_resources_from_table,
+    load_obj_resources_from_table,
     load_str_params,
     load_ws_models_from_table,
     parse_str_param,
 )
 from bdd_dsl.execution.behaviour import Behaviour
-from bdd_dsl.execution.scenario import ExecutionModel
+from bdd_dsl.execution.scenario import ScenarioExecutionModel
 from bdd_dsl.models.user_story import ScenarioVariantModel, UserStoryLoader
 
 
@@ -38,12 +38,7 @@ def before_all_mockup(context: Context):
     g = getattr(context, "model_graph", None)
     assert g is not None, "'model_graph' attribute not found in context"
 
-    exec_model = ExecutionModel(graph=g, bhv_loaders=[load_py_module_attr])
-    context.execution_model = exec_model
     context.us_loader = UserStoryLoader(graph=g)
-
-    generic_loader = ModelLoader()
-    context.ws_model_loader = generic_loader
 
 
 def before_scenario(context: Context, scenario: Scenario):
@@ -77,9 +72,40 @@ def before_scenario(context: Context, scenario: Scenario):
         f"scene '{scenario_var_model.scene.id}' has no agent"
     )
 
-    scenario_var_model.scene.element_loader.register(load_attr_path)
-    scenario_var_model.scene.element_loader.register(load_py_module_attr)
+    scenario_exec = ScenarioExecutionModel(
+        graph=model_graph,
+        scr_var=scenario_var_model,
+        bhv_loaders=[load_py_module_attr],
+    )
     context.current_scenario = scenario_var_model
+    context.current_scenario_execution = scenario_exec
+    context.current_scene_instance = SceneInstanceModel(
+        scenario_exec.scene_inst_id,
+        model_graph,
+        scene_model=scenario_var_model.scene,
+    )
+
+
+def _resources_by_type(
+    resources: dict[URIRef, ModelBase], model_type: URIRef
+) -> tuple[ModelBase, ...]:
+    return tuple(resource for resource in resources.values() if model_type in resource.types)
+
+
+def _check_resource_metadata(
+    owner: str, owner_id: URIRef, resources: dict[URIRef, ModelBase]
+) -> None:
+    for resource in _resources_by_type(resources, URI_PY_TYPE_MODULE_ATTR):
+        assert resource.has_attr(key=URI_PY_PRED_MODULE_NAME), (
+            f"Python attribute model '{resource.id}' for {owner} '{owner_id}' missing module name"
+        )
+        assert resource.has_attr(key=URI_PY_PRED_ATTR_NAME), (
+            f"Python attribute model '{resource.id}' for {owner} '{owner_id}' missing attribute name"
+        )
+    for resource in _resources_by_type(resources, URI_EXEC_TYPE_RES_PATH):
+        assert resource.has_attr(URI_EXEC_PRED_PATH), (
+            f"ResourceWithPath model '{resource.id}' for {owner} '{owner_id}' missing attr path"
+        )
 
 
 def given_objects_mockup(context: Context):
@@ -88,25 +114,12 @@ def given_objects_mockup(context: Context):
     assert context.current_scenario is not None, (
         "no 'current_scenario' in context, expected a ScenarioVariantModel"
     )
-    for obj_model in load_obj_models_from_table(
-        table=context.table, graph=context.model_graph, scene=context.current_scenario.scene
+    scene_inst = context.current_scene_instance
+    assert isinstance(scene_inst, SceneInstanceModel)
+    for obj_id, resources in load_obj_resources_from_table(
+        table=context.table, graph=context.model_graph, scene_inst=scene_inst
     ):
-        if URI_PY_TYPE_MODULE_ATTR in obj_model.model_types:
-            for py_model_uri in obj_model.model_type_to_id[URI_PY_TYPE_MODULE_ATTR]:
-                py_model = obj_model.models[py_model_uri]
-                assert py_model.has_attr(key=URI_PY_PRED_MODULE_NAME), (
-                    f"Python attribute model '{py_model.id}' for object '{obj_model.id}' missing module name"
-                )
-                assert py_model.has_attr(key=URI_PY_PRED_ATTR_NAME), (
-                    f"Python attribute model '{py_model.id}' for object '{obj_model.id}' missing attribute name"
-                )
-
-        if URI_EXEC_TYPE_RES_PATH in obj_model.model_types:
-            for py_model_uri in obj_model.model_type_to_id[URI_EXEC_TYPE_RES_PATH]:
-                path_model = obj_model.load_first_model_by_type(model_type=URI_EXEC_TYPE_RES_PATH)
-                assert path_model.has_attr(URI_EXEC_PRED_PATH), (
-                    f"ResourceWithPath model '{path_model.id}' for object '{obj_model.id}' missing attr path"
-                )
+        _check_resource_metadata("object", obj_id, resources)
 
 
 def given_workspaces_mockup(context: Context):
@@ -118,27 +131,11 @@ def given_workspaces_mockup(context: Context):
     for ws_model in load_ws_models_from_table(
         table=context.table, graph=context.model_graph, scene=context.current_scenario.scene
     ):
-        for obj_model in context.current_scenario.scene.load_ws_objects(
-            graph=context.model_graph, ws_id=ws_model.id
-        ):
-            if URI_PY_TYPE_MODULE_ATTR in obj_model.model_types:
-                for py_model_uri in obj_model.model_type_to_id[URI_PY_TYPE_MODULE_ATTR]:
-                    py_model = obj_model.models[py_model_uri]
-                    assert py_model.has_attr(key=URI_PY_PRED_MODULE_NAME), (
-                        f"Python attribute model '{py_model.id}' for object '{obj_model.id}' missing module name"
-                    )
-                    assert py_model.has_attr(key=URI_PY_PRED_ATTR_NAME), (
-                        f"Python attribute model '{py_model.id}' for object '{obj_model.id}' missing attribute name"
-                    )
-
-            if URI_EXEC_TYPE_RES_PATH in obj_model.model_types:
-                for py_model_uri in obj_model.model_type_to_id[URI_EXEC_TYPE_RES_PATH]:
-                    path_model = obj_model.load_first_model_by_type(
-                        model_type=URI_EXEC_TYPE_RES_PATH
-                    )
-                    assert path_model.has_attr(URI_EXEC_PRED_PATH), (
-                        f"ResourceWithPath model '{path_model.id}' for object '{obj_model.id}' missing attr path"
-                    )
+        scene_inst = context.current_scene_instance
+        assert isinstance(scene_inst, SceneInstanceModel)
+        for obj_id in context.current_scenario.scene.iter_workspace_objects(ws_model.id):
+            resources = scene_inst.object_models.get(obj_id, {})
+            _check_resource_metadata("object", obj_id, resources)
 
 
 def given_agents_mockup(context: Context):
@@ -147,18 +144,12 @@ def given_agents_mockup(context: Context):
     assert context.current_scenario is not None, (
         "no 'current_scenario' in context, expected an ScenarioVariantModel"
     )
-    for agn_model in load_agn_models_from_table(
-        table=context.table, graph=context.model_graph, scene=context.current_scenario.scene
+    scene_inst = context.current_scene_instance
+    assert isinstance(scene_inst, SceneInstanceModel)
+    for agn_id, resources in load_agn_resources_from_table(
+        table=context.table, graph=context.model_graph, scene_inst=scene_inst
     ):
-        if URI_PY_TYPE_MODULE_ATTR in agn_model.model_types:
-            for py_model_uri in agn_model.model_type_to_id[URI_PY_TYPE_MODULE_ATTR]:
-                py_model = agn_model.models[py_model_uri]
-                assert py_model.has_attr(key=URI_PY_PRED_MODULE_NAME), (
-                    f"Python attribute model '{py_model.id}' for agent '{agn_model.id}' missing module name"
-                )
-                assert py_model.has_attr(key=URI_PY_PRED_ATTR_NAME), (
-                    f"Python attribute model '{py_model.id}' for agent '{agn_model.id}' missing attribute name"
-                )
+        _check_resource_metadata("agent", agn_id, resources)
 
 
 def given_scene_mockup(context: Context):
@@ -177,24 +168,19 @@ def is_located_at_mockup(context: Context, **kwargs: Any):
         param_str=params[PARAM_OBJ], ns_manager=context.model_graph.namespace_manager
     )
     for obj_uri in pick_obj_uris:
-        obj_model = context.current_scenario.scene.load_obj_model(
-            graph=context.model_graph, obj_id=obj_uri
-        )
-        assert obj_model is not None, f"can't load model for object {obj_uri}"
-        if URI_PY_TYPE_MODULE_ATTR in obj_model.model_types:
-            py_model = obj_model.load_first_model_by_type(URI_PY_TYPE_MODULE_ATTR)
-            assert py_model.has_attr(key=URI_PY_PRED_MODULE_NAME), (
-                f"Python attribute model '{py_model.id}' for object '{obj_model.id}' missing module name"
-            )
-            assert py_model.has_attr(key=URI_PY_PRED_ATTR_NAME), (
-                f"Python attribute model '{py_model.id}' for object '{obj_model.id}' missing attribute name"
-            )
+        scene_inst = context.current_scene_instance
+        assert isinstance(scene_inst, SceneInstanceModel)
+        resources = scene_inst.object_models.get(obj_uri, {})
+        _check_resource_metadata("object", obj_uri, resources)
 
     _, pick_ws_uris = parse_str_param(
         param_str=params[PARAM_WS], ns_manager=context.model_graph.namespace_manager
     )
     for ws_uri in pick_ws_uris:
-        _ = context.current_scenario.scene.load_ws_model(graph=context.model_graph, ws_id=ws_uri)
+        if ws_uri not in context.current_scenario.scene.workspaces:
+            raise ValueError(
+                f"workspace '{ws_uri}' is not in scene '{context.current_scenario.scene.id}'"
+            )
 
     evt_uri = try_expand_curie(
         curie_str=params[PARAM_EVT], ns_manager=context.model_graph.namespace_manager, quiet=False
@@ -209,14 +195,7 @@ def move_safe_mockup(context: Context, **kwargs: Any):
     )
 
     params = load_str_params(param_names=[PARAM_AGN, PARAM_FROM_EVT, PARAM_UNTIL_EVT], **kwargs)
-    _, pickplace_agn_uris = parse_str_param(
-        param_str=params[PARAM_AGN], ns_manager=context.model_graph.namespace_manager
-    )
-    for agn_uri in pickplace_agn_uris:
-        agn_model = context.current_scenario.scene.load_agn_model(
-            graph=context.model_graph, agent_id=agn_uri
-        )
-        assert agn_model is not None, f"can't load model for agent {agn_uri}"
+    parse_str_param(param_str=params[PARAM_AGN], ns_manager=context.model_graph.namespace_manager)
 
 
 class PickplaceBehaviourMockup(Behaviour):
@@ -297,9 +276,9 @@ def behaviour_mockup(context: Context, **kwargs: Any):
     behaviour_model = getattr(context, "behaviour_model", None)
 
     if behaviour_model is None:
-        exec_model = getattr(context, "execution_model", None)
-        assert isinstance(exec_model, ExecutionModel), (
-            f"no valid 'execution_model' added to the context: {exec_model}"
+        scenario_exec = getattr(context, "current_scenario_execution", None)
+        assert isinstance(scenario_exec, ScenarioExecutionModel), (
+            f"no valid 'current_scenario_execution' added to the context: {scenario_exec}"
         )
 
         model_graph = getattr(context, "model_graph", None)
@@ -307,7 +286,7 @@ def behaviour_mockup(context: Context, **kwargs: Any):
             f"no 'model_graph' of type rdflib.Graph in context: {model_graph}"
         )
 
-        behaviour_model = exec_model.load_behaviour_impl(
+        behaviour_model = scenario_exec.load_behaviour_impl(
             context=context,
             ns_manager=model_graph.namespace_manager,
         )

--- a/src/bdd_dsl/execution/scenario.py
+++ b/src/bdd_dsl/execution/scenario.py
@@ -2,16 +2,15 @@
 from typing import Any
 
 from behave.runner import Context
-from rdf_utils.caching import read_url_and_cache
-from rdf_utils.models.common import AttrLoaderProtocol, ModelBase, ModelLoader
+from rdf_utils.models.common import AttrLoaderProtocol, ModelBase
 from rdf_utils.models.python import (
     URI_PY_TYPE_MODULE_ATTR,
     import_attr_from_model,
 )
-from rdflib import Graph, URIRef
+from rdf_utils.models.vocab import URI_EXEC_PRED_RUNS_SCENE, URI_EXEC_TYPE_SCENE_INST
+from rdflib import RDF, Graph, URIRef
 
 from bdd_dsl.execution.behaviour import Behaviour, BehaviourImplModel
-from bdd_dsl.execution.common import URL_Q_SCENARIO_EXEC
 from bdd_dsl.models.time_constraint import get_duration
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_HAS_BHV_IMPL,
@@ -32,6 +31,7 @@ class ScenarioExecutionModel(ModelBase):
     end_event: URIRef
     bhv_impl: BehaviourImplModel
     obs_policy_uris: set[URIRef]
+    scene_inst_id: URIRef
 
     def __init__(
         self,
@@ -51,6 +51,17 @@ class ScenarioExecutionModel(ModelBase):
         super().__init__(graph=graph, node_id=scr_exec_ids[0])
         if URI_BDD_TYPE_SCENARIO_EXEC not in self.types:
             raise ValueError(f"'{self.id}' missing expected ScenarioExecution type: {self.types}")
+
+        scene_inst_ids = list(graph.objects(self.id, URI_EXEC_PRED_RUNS_SCENE))
+        if len(scene_inst_ids) != 1 or not isinstance(scene_inst_ids[0], URIRef):
+            raise ValueError(
+                f"ScenarioExecution '{self.id}' must run exactly 1 scene instance: {scene_inst_ids}"
+            )
+        self.scene_inst_id = scene_inst_ids[0]
+        if (self.scene_inst_id, RDF.type, URI_EXEC_TYPE_SCENE_INST) not in graph:
+            raise TypeError(
+                f"ScenarioExecution '{self.id}' runs non-SceneInstance '{self.scene_inst_id}'"
+            )
 
         # Boundary events
         dur = get_duration(scr_var.tmpl)
@@ -88,79 +99,24 @@ class ScenarioExecutionModel(ModelBase):
                 )
             self.obs_policy_uris.add(obs_pol_id)
 
-
-class ExecutionModel:
-    _bhv_impl_by_scr_var: dict[URIRef, BehaviourImplModel]
-    _scr_exec_by_scr_var: dict[URIRef, ModelBase]
-    _scr_exec_graph: Graph
-    bhv_model_loader: ModelLoader
-
-    def __init__(self, graph: Graph, bhv_loaders: list[AttrLoaderProtocol]) -> None:
-        g_query_str = read_url_and_cache(URL_Q_SCENARIO_EXEC)
-        q_result = graph.query(g_query_str)
-        assert q_result.type == "CONSTRUCT" and q_result.graph is not None, (
-            "ScenarioExecution query did not return a graph"
-        )
-        assert len(q_result.graph) > 0, "ScenarioExecution query returns an empty graph"
-        self._scr_exec_graph = q_result.graph
-
-        self._bhv_impl_by_scr_var = {}
-        self._scr_exec_by_scr_var = {}
-
-        self.bhv_model_loader = ModelLoader()
-        for loader in bhv_loaders:
-            self.bhv_model_loader.register(loader=loader)
-
     def load_behaviour_impl(self, context: Context, **kwargs: Any) -> BehaviourImplModel:
-        assert hasattr(context, "model_graph"), "'model_graph' not added to behave context"
-        assert isinstance(context.model_graph, Graph), (
-            "load_bhv_impl: 'model_graph' not a rdflib.Graph"
-        )
-        assert hasattr(context, "current_scenario"), (
-            "'current_scenario' not added to behave context"
-        )
-        assert isinstance(context.current_scenario, ScenarioVariantModel), (
-            "load_bhv_impl: 'context.current_scenario' not a ScenarioVariantModel"
-        )
+        if self.bhv_impl.behaviour is not None:
+            return self.bhv_impl
 
-        scr_var_id = context.current_scenario.id
-        if scr_var_id in self._bhv_impl_by_scr_var:
-            return self._bhv_impl_by_scr_var[scr_var_id]
-
-        scr_exec_id = self._scr_exec_graph.value(
-            predicate=URI_BDD_PRED_OF_VARIANT, object=scr_var_id, any=False
-        )
-        assert isinstance(scr_exec_id, URIRef), (
-            f"'{scr_var_id}' doesn't link to a ScenarioExecution URI: {scr_exec_id}"
-        )
-        scr_exec_model = ModelBase(node_id=scr_exec_id, graph=self._scr_exec_graph)
-        self._scr_exec_by_scr_var[scr_var_id] = scr_exec_model
-
-        bhv_impl_id = self._scr_exec_graph.value(
-            subject=scr_exec_id, predicate=URI_BDD_PRED_HAS_BHV_IMPL, any=False
-        )
-        assert isinstance(bhv_impl_id, URIRef), (
-            f"ScenarioExecution '{scr_exec_id}' doesn't link to a BehaviourImplementation URI: {bhv_impl_id}"
-        )
-        bhv_impl = BehaviourImplModel(graph=self._scr_exec_graph, bhv_impl_id=bhv_impl_id)
-
-        self.bhv_model_loader.load_attributes(graph=context.model_graph, model=bhv_impl)
-
-        if URI_PY_TYPE_MODULE_ATTR in bhv_impl.types:
-            bhv_cls = import_attr_from_model(model=bhv_impl)
+        if URI_PY_TYPE_MODULE_ATTR in self.bhv_impl.types:
+            bhv_cls = import_attr_from_model(model=self.bhv_impl)
             assert issubclass(bhv_cls, Behaviour), (
-                f"Implementation for '{bhv_impl.id}' is not an extension of '{Behaviour}'"
+                f"Implementation for '{self.bhv_impl.id}' is not an extension of '{Behaviour}'"
             )
-            bhv_impl.behaviour = bhv_cls(
-                bhv_id=bhv_impl.behaviour_uri,
-                bhv_types=bhv_impl.behaviour_types,
+            self.bhv_impl.behaviour = bhv_cls(
+                bhv_id=self.bhv_impl.behaviour_uri,
+                bhv_types=self.bhv_impl.behaviour_types,
                 context=context,
                 **kwargs,
             )
 
-        assert bhv_impl.behaviour is not None, (
-            f"no behaviour type handled for BehaviourImpl '{bhv_impl.id}', types: {bhv_impl.types}"
+        assert self.bhv_impl.behaviour is not None, (
+            f"no behaviour type handled for BehaviourImpl '{self.bhv_impl.id}', "
+            f"types: {self.bhv_impl.types}"
         )
-
-        self._bhv_impl_by_scr_var[scr_var_id] = bhv_impl
-        return bhv_impl
+        return self.bhv_impl

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -1,23 +1,25 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 from urllib.request import HTTPError
 
 from rdf_utils.constraints import check_shacl_constraints
-from rdf_utils.models.execution import load_attr_path
-from rdf_utils.models.python import (
-    URI_PY_PRED_ATTR_NAME,
-    URI_PY_PRED_MODULE_NAME,
-    URI_PY_TYPE_MODULE_ATTR,
-    load_py_module_attr,
-)
-from rdf_utils.models.vocab import URI_EXEC_PRED_PATH, URI_EXEC_TYPE_SYS_RES
+from rdf_utils.models.vocab import URI_EXEC_PRED_RUNS_SCENE, URI_EXEC_TYPE_SCENE_INST
 from rdf_utils.namespace import URL_MM_PYTHON_SHACL, URL_SECORO_M
 from rdf_utils.resolver import install_resolver
-from rdflib import Dataset
-from scene_dsl.rdf_parser.agent import AgentModel
-from scene_dsl.rdf_parser.environment import ObjectModel
+from rdflib import RDF, Dataset, Graph, URIRef
 
 from bdd_dsl.execution.common import URL_MM_EXEC_SHACL
+from bdd_dsl.execution.scenario import ScenarioExecutionModel
+from bdd_dsl.models.urirefs import (
+    URI_BDD_PRED_HAS_BHV_IMPL,
+    URI_BDD_PRED_OF_VARIANT,
+    URI_BDD_TYPE_SCENARIO_EXEC,
+    URI_BHV_PRED_OF_BHV,
+    URI_TIME_PRED_AFTER_EVT,
+    URI_TIME_PRED_BEFORE_EVT,
+)
 from bdd_dsl.models.user_story import UserStoryLoader
 
 SPEC_MODEL_URLS = {
@@ -60,73 +62,53 @@ class BDDExecTest(unittest.TestCase):
 
         check_shacl_constraints(graph=self.graph, shacl_dict=SHACL_URLS)
 
-    def _test_obj_model(self, obj_model: ObjectModel):
-        if URI_EXEC_TYPE_SYS_RES in obj_model.model_types:
-            self.assertTrue(
-                len(obj_model.model_type_to_id[URI_EXEC_TYPE_SYS_RES]) > 0,
-                f"Object '{obj_model.id}' has type '{URI_EXEC_TYPE_SYS_RES}' but no corresponding model",
-            )
-            for model_id in obj_model.model_type_to_id[URI_EXEC_TYPE_SYS_RES]:
-                self.assertTrue(obj_model.models[model_id].has_attr(URI_EXEC_PRED_PATH))
-
-        elif URI_PY_TYPE_MODULE_ATTR in obj_model.model_types:
-            self.assertTrue(
-                len(obj_model.model_type_to_id[URI_PY_TYPE_MODULE_ATTR]) > 0,
-                f"Object '{obj_model.id}' has type '{URI_PY_TYPE_MODULE_ATTR}' but no corresponding model",
-            )
-            for model_id in obj_model.model_type_to_id[URI_PY_TYPE_MODULE_ATTR]:
-                module_name = obj_model.models[model_id].get_attr(key=URI_PY_PRED_MODULE_NAME)
-                attr_name = obj_model.models[model_id].get_attr(key=URI_PY_PRED_ATTR_NAME)
-                self.assertTrue(
-                    module_name is not None,
-                    f"PyModuleAttribute model '{model_id}' for Object '{obj_model.id}' has no module name",
-                )
-                self.assertTrue(
-                    attr_name is not None,
-                    f"PyModuleAttribute model '{model_id}' for Object '{obj_model.id}' has no attribute name",
-                )
-
-    def _test_agn_model(self, agn_model: AgentModel):
-        if URI_PY_TYPE_MODULE_ATTR in agn_model.model_types:
-            self.assertTrue(
-                len(agn_model.model_type_to_id[URI_PY_TYPE_MODULE_ATTR]) > 0,
-                f"Agent '{agn_model.id}' has type '{URI_PY_TYPE_MODULE_ATTR}' but no corresponding model",
-            )
-            for model_id in agn_model.model_type_to_id[URI_PY_TYPE_MODULE_ATTR]:
-                module_name = agn_model.models[model_id].get_attr(key=URI_PY_PRED_MODULE_NAME)
-                attr_name = agn_model.models[model_id].get_attr(key=URI_PY_PRED_ATTR_NAME)
-                self.assertTrue(
-                    module_name is not None,
-                    f"PyModuleAttribute model '{model_id}' for Agent '{agn_model.id}' has no module name",
-                )
-                self.assertTrue(
-                    attr_name is not None,
-                    f"PyModuleAttribute model '{model_id}' for Agent '{agn_model.id}' has no attribute name",
-                )
-
-    def test_exec(self):
+    def test_user_story_scenes_load_without_execution_models(self):
         for scenario_variant_uris in self.us_loader.get_us_scenario_variants().values():
             for scr_var_uri in scenario_variant_uris:
                 scr_var = self.us_loader.load_scenario_variant(
                     full_graph=self.graph, variant_id=scr_var_uri
                 )
-                scr_var.scene.element_loader.register(load_attr_path)
-                scr_var.scene.element_loader.register(load_py_module_attr)
-                for obj_id in scr_var.scene.objects:
-                    obj_model = scr_var.scene.element_loader.load_object_model(
-                        obj_id=obj_id, graph=self.graph
-                    )
-                    self._test_obj_model(obj_model=obj_model)
+                self.assertTrue(scr_var.scene.objects)
 
-                for ws_id in scr_var.scene.workspaces:
-                    for obj_model in scr_var.scene.load_ws_objects(ws_id=ws_id, graph=self.graph):
-                        self._test_obj_model(obj_model=obj_model)
+    def test_scenario_execution_selects_exact_scene_instance(self):
+        graph = Graph()
+        variant = URIRef("urn:test:variant")
+        execution = URIRef("urn:test:execution")
+        scene_inst = URIRef("urn:test:scene-instance")
+        bhv_impl = URIRef("urn:test:behaviour-implementation")
+        behaviour = URIRef("urn:test:behaviour")
+        graph.add((execution, RDF.type, URI_BDD_TYPE_SCENARIO_EXEC))
+        graph.add((execution, URI_BDD_PRED_OF_VARIANT, variant))
+        graph.add((execution, URI_EXEC_PRED_RUNS_SCENE, scene_inst))
+        graph.add((scene_inst, RDF.type, URI_EXEC_TYPE_SCENE_INST))
+        graph.add((execution, URI_BDD_PRED_HAS_BHV_IMPL, bhv_impl))
+        graph.add((bhv_impl, RDF.type, URIRef("urn:test:Implementation")))
+        graph.add((bhv_impl, URI_BHV_PRED_OF_BHV, behaviour))
+        graph.add((behaviour, RDF.type, URIRef("urn:test:Behaviour")))
+        scr_var = SimpleNamespace(id=variant, tmpl=object())
+        duration = {
+            URI_TIME_PRED_AFTER_EVT: URIRef("urn:test:start"),
+            URI_TIME_PRED_BEFORE_EVT: URIRef("urn:test:end"),
+        }
 
-                for agn_id in scr_var.scene.agents:
-                    agn_model = scr_var.scene.element_loader.load_agent_model(
-                        agent_id=agn_id, graph=self.graph
-                    )
-                    self._test_agn_model(agn_model=agn_model)
+        with patch("bdd_dsl.execution.scenario.get_duration", return_value=duration):
+            model = ScenarioExecutionModel(graph, scr_var, bhv_loaders=[])
+            self.assertEqual(model.scene_inst_id, scene_inst)
+
+            other_scene = URIRef("urn:test:other-scene-instance")
+            graph.add((other_scene, RDF.type, URI_EXEC_TYPE_SCENE_INST))
+            graph.add((execution, URI_EXEC_PRED_RUNS_SCENE, other_scene))
+            with self.assertRaisesRegex(ValueError, "exactly 1 scene instance"):
+                ScenarioExecutionModel(graph, scr_var, bhv_loaders=[])
+            graph.remove((execution, URI_EXEC_PRED_RUNS_SCENE, other_scene))
+
+            graph.remove((execution, URI_EXEC_PRED_RUNS_SCENE, scene_inst))
+            with self.assertRaisesRegex(ValueError, "exactly 1 scene instance"):
+                ScenarioExecutionModel(graph, scr_var, bhv_loaders=[])
+
+            graph.add((execution, URI_EXEC_PRED_RUNS_SCENE, URIRef("urn:test:not-scene")))
+            with self.assertRaisesRegex(TypeError, "non-SceneInstance"):
+                ScenarioExecutionModel(graph, scr_var, bhv_loaders=[])
 
 
 if __name__ == "__main__":

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -119,9 +119,7 @@ class BDDExecTest(unittest.TestCase):
                     self._test_obj_model(obj_model=obj_model)
 
                 for ws_id in scr_var.scene.workspaces:
-                    for obj_model in scr_var.scene.element_loader.load_ws_objects(
-                        ws_id=ws_id, graph=self.graph
-                    ):
+                    for obj_model in scr_var.scene.load_ws_objects(ws_id=ws_id, graph=self.graph):
                         self._test_obj_model(obj_model=obj_model)
 
                 for agn_id in scr_var.scene.agents:


### PR DESCRIPTION
## Description

Adapts `bdd-dsl` to the scene/resource model introduced by companion PR secorolab/scene-dsl#24.

- Selects exactly one `ScenarioExecutionModel` for each scenario variant.
- Resolves its concrete scene instance through exec:runs-scene.
- Uses instance-owned object and agent model dictionaries instead of mutating `SceneModel`.
- Allows abstract scene elements without executable resources while still validating metadata when resources exist.
- Removes the global `ExecutionModel` query/cache and obsolete object/agent model-loading APIs.

## Compatibility

Scenario execution RDF must now provide exactly one `exec:runs-scene` target typed as `exec:SceneInstance`. The instance must reference the scene used by the scenario variant.