### PR TITLE
feat(observation): evaluate cached Python policy inputs

### DIFF
--- a/src/bdd_dsl/execution/mockup.py
+++ b/src/bdd_dsl/execution/mockup.py
@@ -79,11 +79,7 @@ def before_scenario(context: Context, scenario: Scenario):
     )
     context.current_scenario = scenario_var_model
     context.current_scenario_execution = scenario_exec
-    context.current_scene_instance = SceneInstanceModel(
-        scenario_exec.scene_inst_id,
-        model_graph,
-        scene_model=scenario_var_model.scene,
-    )
+    context.current_scene_instance = scenario_exec.scene_instance
 
 
 def _resources_by_type(

--- a/src/bdd_dsl/execution/scenario.py
+++ b/src/bdd_dsl/execution/scenario.py
@@ -9,6 +9,7 @@ from rdf_utils.models.python import (
 )
 from rdf_utils.models.vocab import URI_EXEC_PRED_RUNS_SCENE, URI_EXEC_TYPE_SCENE_INST
 from rdflib import RDF, Graph, URIRef
+from scene_dsl.rdf_parser.scenex import SceneInstanceModel
 
 from bdd_dsl.execution.behaviour import Behaviour, BehaviourImplModel
 from bdd_dsl.models.time_constraint import get_duration
@@ -31,7 +32,7 @@ class ScenarioExecutionModel(ModelBase):
     end_event: URIRef
     bhv_impl: BehaviourImplModel
     obs_policy_uris: set[URIRef]
-    scene_inst_id: URIRef
+    scene_instance: SceneInstanceModel
 
     def __init__(
         self,
@@ -57,11 +58,16 @@ class ScenarioExecutionModel(ModelBase):
             raise ValueError(
                 f"ScenarioExecution '{self.id}' must run exactly 1 scene instance: {scene_inst_ids}"
             )
-        self.scene_inst_id = scene_inst_ids[0]
-        if (self.scene_inst_id, RDF.type, URI_EXEC_TYPE_SCENE_INST) not in graph:
+        scene_inst_id = scene_inst_ids[0]
+        if (scene_inst_id, RDF.type, URI_EXEC_TYPE_SCENE_INST) not in graph:
             raise TypeError(
-                f"ScenarioExecution '{self.id}' runs non-SceneInstance '{self.scene_inst_id}'"
+                f"ScenarioExecution '{self.id}' runs non-SceneInstance '{scene_inst_id}'"
             )
+        self.scene_instance = SceneInstanceModel(
+            scene_inst_id,
+            graph,
+            scene_model=scr_var.scene,
+        )
 
         # Boundary events
         dur = get_duration(scr_var.tmpl)

--- a/src/bdd_dsl/models/namespace.py
+++ b/src/bdd_dsl/models/namespace.py
@@ -17,6 +17,8 @@ NS_MM_TASK = Namespace(URI_MM_TASK)
 NS_MM_SIM = Namespace(URI_MM_SIM)
 NS_MM_OBS = Namespace(URI_MM_OBS)
 NS_MM_ROS = Namespace(URI_MM_ROS)
+NS_MM_CSTR = Namespace("https://comp-rob2b.github.io/metamodels/task/constraint#")
+NS_MM_CSTR_EXT = Namespace("https://secorolab.github.io/metamodels/task/constraint#")
 
 # Prefixes
 PREFIX_GEOM = "geom"

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -448,6 +448,8 @@ class ObservationManager:
         """Resolve template-variable targets for this scenario context."""
         for policy in self.obs_policies.values():
             for obs_uri, target_uri in policy.observation_targets.items():
+                if target_uri is None:
+                    continue
                 bound_target = bindings.get(target_uri)
                 if bound_target is not None:
                     if not isinstance(bound_target, URIRef):

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 from rdf_utils.models.common import AttrLoaderProtocol, ModelBase
+from rdf_utils.models.python import (
+    URI_PY_TYPE_MODULE_ATTR,
+    import_attr_from_model,
+    load_py_module_attr,
+)
 from rdflib import Graph, URIRef
 from trinary import Trinary, Unknown
 
@@ -14,6 +19,8 @@ from bdd_dsl.models.clauses import FluentClauseModel
 from bdd_dsl.models.time_constraint import get_duration
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_OF_CLAUSE,
+    URI_OBS_PRED_HAS_OBSERVATION,
+    URI_OBS_PRED_PROVIDER,
     URI_OBS_TYPE_POLICY,
     URI_TIME_PRED_AFTER_EVT,
     URI_TIME_PRED_BEFORE_EVT,
@@ -25,7 +32,23 @@ from bdd_dsl.models.urirefs import (
 from bdd_dsl.models.user_story import ScenarioVariantModel
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
+class ObservationStamped:
+    observation_uri: URIRef
+    provider_uri: URIRef
+    stamp: float
+    value: Any
+
+
+class TimestampedObservationProtocol(Protocol):
+    def __call__(self, observation: Any, receipt_stamp: float) -> float: ...
+
+
+class ObservationPolicyEvaluatorProtocol(Protocol):
+    def __call__(self, observations: list[ObservationStamped]) -> bool | Trinary: ...
+
+
+@dataclass(frozen=True, slots=True)
 class TrinaryStamped:
     stamp: float
     trinary: Trinary | bool
@@ -50,6 +73,9 @@ def trin_policy_and(trinaries: list[TrinaryStamped], **kwargs: Any) -> bool | Tr
 
 class ObsPolicyModel(ModelBase):
     trinary_timeline: list[TrinaryStamped]
+    observation_uris: set[URIRef]
+    observation_providers: dict[URIRef, URIRef]
+    evaluator: ObservationPolicyEvaluatorProtocol | None
 
     start_time: float | None
     end_time: float | None
@@ -85,6 +111,29 @@ class ObsPolicyModel(ModelBase):
         self.horizon = horizon
 
         self.trinary_timeline = []
+        self.observation_uris = set()
+        self.observation_providers = {}
+        for observation_uri in graph.objects(subject=self.id, predicate=URI_OBS_PRED_HAS_OBSERVATION):
+            if not isinstance(observation_uri, URIRef):
+                raise TypeError(
+                    f"ObservationPolicy '{self.id}' links to non-URI observation: {observation_uri}"
+                )
+            provider_uri = graph.value(
+                subject=observation_uri, predicate=URI_OBS_PRED_PROVIDER, any=False)
+            if not isinstance(provider_uri, URIRef):
+                raise TypeError(
+                    f"Observation '{observation_uri}' has invalid provider: {provider_uri}"
+                )
+            self.observation_uris.add(observation_uri)
+            self.observation_providers[observation_uri] = provider_uri
+
+        self.evaluator = None
+        if URI_PY_TYPE_MODULE_ATTR in self.types:
+            load_py_module_attr(graph=graph, model=self, quiet=False)
+            evaluator = import_attr_from_model(model=self)
+            if not callable(evaluator):
+                raise TypeError(f"ObservationPolicy '{self.id}' Python attribute is not callable")
+            self.evaluator = evaluator
 
         self.start_time = None
         self.end_time = None
@@ -263,6 +312,8 @@ class ObservationManager:
 
     obs_policies: dict[URIRef, ObsPolicyModel]  # policy ID -> ObsPolicyModel
     _fluent_policy_registry: dict[URIRef, set[URIRef]]  # fluent ID -> policy IDs
+    observation_cache: dict[URIRef, ObservationStamped]
+    _observation_policy_registry: dict[URIRef, URIRef]  # observation ID -> policy ID
 
     event_timelines: dict[URIRef, list[float]]
     _fluent_event_registry: dict[URIRef, set[URIRef]]  # fluent ID -> event IDs
@@ -276,6 +327,8 @@ class ObservationManager:
 
         self.obs_policies = {}
         self._fluent_policy_registry = {}
+        self.observation_cache = {}
+        self._observation_policy_registry = {}
 
         self.event_timelines = {}
         self._fluent_event_registry = {}
@@ -324,6 +377,10 @@ class ObservationManager:
                 loader(graph=graph, model=obs_pol)
 
             self._fluent_policy_registry[fc.id].add(obs_pol.id)
+            for observation_uri in obs_pol.observation_uris:
+                if observation_uri in self._observation_policy_registry:
+                    raise ValueError(f"Observation already registered: '{observation_uri}'")
+                self._observation_policy_registry[observation_uri] = obs_pol.id
             self._register_fluent_event(evt_uri=obs_pol.start_event, fc_id=fc.id)
             self._register_fluent_event(evt_uri=obs_pol.end_event, fc_id=fc.id)
             self.obs_policies[obs_pol.id] = obs_pol
@@ -338,6 +395,38 @@ class ObservationManager:
             raise ValueError(f"ObservationPolicy not registered: '{policy_uri}'")
 
         return self.obs_policies[policy_uri].add_trinary(trin_st)
+
+    def update_observation(self, observation: ObservationStamped) -> tuple[bool, str]:
+        policy_uri = self._observation_policy_registry.get(observation.observation_uri)
+        if policy_uri is None:
+            raise ValueError(f"Observation not registered: '{observation.observation_uri}'")
+
+        policy = self.obs_policies[policy_uri]
+        provider_uri = policy.observation_providers.get(observation.observation_uri)
+        if provider_uri is None:
+            raise ValueError(
+                f"Observation '{observation.observation_uri}' is not configured for policy '{policy_uri}'"
+            )
+        if observation.provider_uri != provider_uri:
+            raise ValueError(
+                f"Observation '{observation.observation_uri}' received from '{observation.provider_uri}', "
+                f"expected '{provider_uri}'"
+            )
+
+        cached = self.observation_cache.get(observation.observation_uri)
+        if cached is not None and observation.stamp < cached.stamp:
+            return False, "(observation) older than cached sample"
+        self.observation_cache[observation.observation_uri] = observation
+        if policy.evaluator is None:
+            return False, "no evaluator"
+        if any(uri not in self.observation_cache for uri in policy.observation_uris):
+            return True, "(observation) waiting for policy inputs"
+
+        observations = [self.observation_cache[uri] for uri in policy.observation_uris]
+        result = policy.evaluator(observations)
+        return policy.add_trinary(
+            TrinaryStamped(stamp=max(sample.stamp for sample in observations), trinary=result)
+        )
 
     def on_event(self, evt_uri: URIRef, evt_t: float):
         if evt_uri not in self.event_timelines:

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -126,26 +126,20 @@ class ObsPolicyModel(ModelBase):
         self.observation_uris = set()
         self.observation_providers = {}
         self.observation_targets = {}
-        for observation_uri in graph.objects(
-            subject=self.id, predicate=URI_OBS_PRED_HAS_OBSERVATION
-        ):
-            if not isinstance(observation_uri, URIRef):
+        for obs_uri in graph.objects(subject=self.id, predicate=URI_OBS_PRED_HAS_OBSERVATION):
+            if not isinstance(obs_uri, URIRef):
                 raise TypeError(
-                    f"ObservationPolicy '{self.id}' links to non-URI observation: {observation_uri}"
+                    f"ObservationPolicy '{self.id}' links to non-URI observation: {obs_uri}"
                 )
-            provider_uri = graph.value(
-                subject=observation_uri, predicate=URI_OBS_PRED_PROVIDER, any=False
-            )
+            provider_uri = graph.value(subject=obs_uri, predicate=URI_OBS_PRED_PROVIDER, any=False)
             if not isinstance(provider_uri, URIRef):
-                raise TypeError(
-                    f"Observation '{observation_uri}' has invalid provider: {provider_uri}"
-                )
-            target_uri = graph.value(observation_uri, URI_OBS_PRED_OBSERVES_TARGET, any=False)
+                raise TypeError(f"Observation '{obs_uri}' has invalid provider: {provider_uri}")
+            target_uri = graph.value(obs_uri, URI_OBS_PRED_OBSERVES_TARGET, any=False)
             if target_uri is not None and not isinstance(target_uri, URIRef):
-                raise TypeError(f"Observation '{observation_uri}' has invalid target: {target_uri}")
-            self.observation_uris.add(observation_uri)
-            self.observation_providers[observation_uri] = provider_uri
-            self.observation_targets[observation_uri] = target_uri
+                raise TypeError(f"Observation '{obs_uri}' has invalid target: {target_uri}")
+            self.observation_uris.add(obs_uri)
+            self.observation_providers[obs_uri] = provider_uri
+            self.observation_targets[obs_uri] = target_uri
 
         self.evaluator = None
         if URI_PY_TYPE_MODULE_ATTR in self.types:
@@ -401,10 +395,10 @@ class ObservationManager:
                 loader(graph=graph, model=obs_pol)
 
             self._fluent_policy_registry[fc.id].add(obs_pol.id)
-            for observation_uri in obs_pol.observation_uris:
-                if observation_uri in self._observation_policy_registry:
-                    raise ValueError(f"Observation already registered: '{observation_uri}'")
-                self._observation_policy_registry[observation_uri] = obs_pol.id
+            for obs_uri in obs_pol.observation_uris:
+                if obs_uri in self._observation_policy_registry:
+                    raise ValueError(f"Observation already registered: '{obs_uri}'")
+                self._observation_policy_registry[obs_uri] = obs_pol.id
             self._register_fluent_event(evt_uri=obs_pol.start_event, fc_id=fc.id)
             self._register_fluent_event(evt_uri=obs_pol.end_event, fc_id=fc.id)
             self.obs_policies[obs_pol.id] = obs_pol
@@ -420,47 +414,41 @@ class ObservationManager:
     def bind_observation_targets(self, bindings: dict[URIRef, Any]) -> None:
         """Resolve template-variable targets for this scenario context."""
         for policy in self.obs_policies.values():
-            for observation_uri, target_uri in policy.observation_targets.items():
+            for obs_uri, target_uri in policy.observation_targets.items():
                 bound_target = bindings.get(target_uri)
                 if bound_target is not None:
                     if not isinstance(bound_target, URIRef):
                         raise TypeError(
                             f"observation target '{target_uri}' is bound to non-URI {bound_target}"
                         )
-                    policy.observation_targets[observation_uri] = bound_target
+                    policy.observation_targets[obs_uri] = bound_target
 
     def update_provider_observation(
         self, provider_uri: URIRef, raw_value: Any, receipt_stamp: float
-    ) -> list[tuple[bool, str]]:
+    ) -> dict[URIRef, tuple[bool, str]]:
         timestamp_extractor, entity_mapper = self._provider_registry.get(provider_uri, (None, None))
         stamp = (
             receipt_stamp
             if timestamp_extractor is None
             else timestamp_extractor(raw_value, receipt_stamp)
         )
-        values = [(None, raw_value)]
+        values: list[tuple[URIRef | None, Any]] = [(None, raw_value)]
         if entity_mapper is not None:
-            for entity_observation in entity_mapper(raw_value):
-                if not isinstance(entity_observation, EntityObservation):
-                    raise TypeError(
-                        f"entity mapper for {provider_uri} returned {type(entity_observation)}"
-                    )
-                values.append((entity_observation.entity_uri, entity_observation.value))
+            for entity_obs in entity_mapper(raw_value):
+                if not isinstance(entity_obs, EntityObservation):
+                    raise TypeError(f"entity mapper for {provider_uri} returned {type(entity_obs)}")
+                values.append((entity_obs.entity_uri, entity_obs.value))
 
-        results = []
-        for observation_uri, policy_uri in self._observation_policy_registry.items():
+        observations = []
+        for obs_uri, policy_uri in self._observation_policy_registry.items():
             policy = self.obs_policies[policy_uri]
-            if policy.observation_providers[observation_uri] != provider_uri:
+            if policy.observation_providers[obs_uri] != provider_uri:
                 continue
-            target_uri = policy.observation_targets[observation_uri]
+            target_uri = policy.observation_targets[obs_uri]
             for entity_uri, value in values:
                 if entity_uri == target_uri:
-                    results.append(
-                        self.update_observation(
-                            ObservationStamped(observation_uri, provider_uri, stamp, value)
-                        )
-                    )
-        return results
+                    observations.append(ObservationStamped(obs_uri, provider_uri, stamp, value))
+        return self.update_observations(observations)
 
     def update_bhv_result(self, trin_st: TrinaryStamped):
         self.bhv_result = trin_st
@@ -473,37 +461,60 @@ class ObservationManager:
 
         return self.obs_policies[policy_uri].add_trinary(trin_st)
 
-    def update_observation(self, observation: ObservationStamped) -> tuple[bool, str]:
-        policy_uri = self._observation_policy_registry.get(observation.observation_uri)
-        if policy_uri is None:
-            raise ValueError(f"Observation not registered: '{observation.observation_uri}'")
+    def update_observations(
+        self, observations: list[ObservationStamped]
+    ) -> dict[URIRef, tuple[bool, str]]:
+        """Atomically cache and evaluate each policy represented in a snapshot."""
+        results: dict[URIRef, tuple[bool, str]] = {}
+        obs_by_policy: dict[URIRef, list[ObservationStamped]] = {}
+        stale_policies: set[URIRef] = set()
+        for obs in observations:
+            policy_uri = self._observation_policy_registry.get(obs.observation_uri)
+            if policy_uri is None:
+                raise ValueError(f"Observation not registered: '{obs.observation_uri}'")
 
-        policy = self.obs_policies[policy_uri]
-        provider_uri = policy.observation_providers.get(observation.observation_uri)
-        if provider_uri is None:
-            raise ValueError(
-                f"Observation '{observation.observation_uri}' is not configured for policy '{policy_uri}'"
+            policy = self.obs_policies[policy_uri]
+            provider_uri = policy.observation_providers.get(obs.observation_uri)
+            if provider_uri is None:
+                raise ValueError(
+                    f"Observation '{obs.observation_uri}' is not configured for policy "
+                    f"'{policy_uri}'"
+                )
+            if obs.provider_uri != provider_uri:
+                raise ValueError(
+                    f"Observation '{obs.observation_uri}' received from "
+                    f"'{obs.provider_uri}', expected '{provider_uri}'"
+                )
+            obs_by_policy.setdefault(policy_uri, []).append(obs)
+            cached = self.observation_cache.get(obs.observation_uri)
+            if cached is not None and obs.stamp < cached.stamp:
+                stale_policies.add(policy_uri)
+
+        for policy_uri, policy_observations in obs_by_policy.items():
+            if policy_uri in stale_policies:
+                results[policy_uri] = (
+                    False,
+                    "(observation) older than cached sample",
+                )
+                continue
+
+            for obs in policy_observations:
+                self.observation_cache[obs.observation_uri] = obs
+
+            policy = self.obs_policies[policy_uri]
+            if policy.evaluator is None:
+                results[policy_uri] = (False, "no evaluator")
+                continue
+            if any(uri not in self.observation_cache for uri in policy.observation_uris):
+                results[policy_uri] = (True, "(observation) waiting for policy inputs")
+                continue
+
+            samples = [self.observation_cache[uri] for uri in policy.observation_uris]
+            result = policy.evaluator(samples)
+            results[policy_uri] = policy.add_trinary(
+                TrinaryStamped(stamp=max(sample.stamp for sample in samples), trinary=result)
             )
-        if observation.provider_uri != provider_uri:
-            raise ValueError(
-                f"Observation '{observation.observation_uri}' received from '{observation.provider_uri}', "
-                f"expected '{provider_uri}'"
-            )
-
-        cached = self.observation_cache.get(observation.observation_uri)
-        if cached is not None and observation.stamp < cached.stamp:
-            return False, "(observation) older than cached sample"
-        self.observation_cache[observation.observation_uri] = observation
-        if policy.evaluator is None:
-            return False, "no evaluator"
-        if any(uri not in self.observation_cache for uri in policy.observation_uris):
-            return True, "(observation) waiting for policy inputs"
-
-        observations = [self.observation_cache[uri] for uri in policy.observation_uris]
-        result = policy.evaluator(observations)
-        return policy.add_trinary(
-            TrinaryStamped(stamp=max(sample.stamp for sample in observations), trinary=result)
-        )
+        return results
 
     def on_event(self, evt_uri: URIRef, evt_t: float):
         if evt_uri not in self.event_timelines:

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -36,6 +36,8 @@ from bdd_dsl.models.user_story import ScenarioVariantModel
 
 @dataclass(frozen=True, slots=True)
 class ObservationStamped:
+    """A normalized value for one policy-local observation input."""
+
     observation_uri: URIRef
     provider_uri: URIRef
     stamp: float
@@ -43,6 +45,8 @@ class ObservationStamped:
 
 
 class TimestampedObservationProtocol(Protocol):
+    """Extract a source timestamp, falling back to the ingress receipt timestamp."""
+
     def __call__(self, observation: Any, receipt_stamp: float) -> float: ...
 
 
@@ -53,10 +57,18 @@ class EntityObservation:
 
 
 class EntityObservationMapperProtocol(Protocol):
+    """Map a raw provider message to zero or more target-specific values."""
+
     def __call__(self, observation: Any) -> list[EntityObservation]: ...
 
 
 class ObservationPolicyEvaluatorProtocol(Protocol):
+    """Evaluate a complete policy snapshot as a trinary or boolean.
+
+    A Python policy attribute may be a function, a callable object, or a no-argument
+    callable class. Classes are instantiated once while the policy model is loaded.
+    """
+
     def __call__(self, observations: list[ObservationStamped]) -> bool | Trinary: ...
 
 
@@ -322,6 +334,15 @@ class ObsPolicyModel(ModelBase):
 
 
 class ObservationManager:
+    """Route provider values into policy-local caches and fluent timelines.
+
+    Register provider adapters after building a scenario context. Feed raw provider
+    messages through :meth:`update_provider_observation`; it extracts a timestamp,
+    maps target-specific values, and evaluates each complete policy snapshot once.
+    :meth:`update_fpolicy_assertion` remains the compatibility ingress for direct
+    ``TrinaryStamped`` topic policies.
+    """
+
     scenario_exec: ScenarioExecutionModel
     scr_start_time: float | None
     scr_end_time: float | None
@@ -380,6 +401,7 @@ class ObservationManager:
     def register_fluent_obs(
         self, graph: Graph, fc: FluentClauseModel, obs_loaders: list[AttrLoaderProtocol]
     ) -> None:
+        """Register execution-selected observation policies for a fluent clause."""
         if fc.id in self._fluent_policy_registry:
             # Already registered
             return
@@ -419,6 +441,7 @@ class ObservationManager:
         timestamp_extractor: TimestampedObservationProtocol | None = None,
         entity_mapper: EntityObservationMapperProtocol | None = None,
     ) -> None:
+        """Register optional timestamp and entity-mapping adapters for a provider."""
         self._provider_registry[provider_uri] = (timestamp_extractor, entity_mapper)
 
     def bind_observation_targets(self, bindings: dict[URIRef, Any]) -> None:
@@ -434,6 +457,7 @@ class ObservationManager:
                     policy.observation_targets[obs_uri] = bound_target
 
     def observation_targets_for_provider(self, provider_uri: URIRef) -> dict[URIRef, URIRef | None]:
+        """Return each configured observation and resolved target for ``provider_uri``."""
         return {
             obs_uri: policy.observation_targets[obs_uri]
             for policy in self.obs_policies.values()
@@ -444,6 +468,10 @@ class ObservationManager:
     def update_provider_observation(
         self, provider_uri: URIRef, raw_value: Any, receipt_stamp: float
     ) -> dict[URIRef, tuple[bool, str]]:
+        """Normalize one raw provider value and route it to matching observations.
+
+        Without an entity mapper, only targetless observations receive the raw value.
+        """
         timestamp_extractor, entity_mapper = self._provider_registry.get(provider_uri, (None, None))
         stamp = (
             receipt_stamp
@@ -469,11 +497,13 @@ class ObservationManager:
         return self.update_observations(observations)
 
     def update_bhv_result(self, trin_st: TrinaryStamped):
+        """Record the behaviour result that closes the active scenario context."""
         self.bhv_result = trin_st
 
     def update_fpolicy_assertion(
         self, policy_uri: URIRef, trin_st: TrinaryStamped
     ) -> tuple[bool, str]:
+        """Insert a direct trinary assertion for a legacy topic-backed policy."""
         if policy_uri not in self.obs_policies:
             raise ValueError(f"ObservationPolicy not registered: '{policy_uri}'")
 
@@ -482,7 +512,11 @@ class ObservationManager:
     def update_observations(
         self, observations: list[ObservationStamped]
     ) -> dict[URIRef, tuple[bool, str]]:
-        """Atomically cache and evaluate each policy represented in a snapshot."""
+        """Cache normalized inputs atomically and evaluate each represented policy once.
+
+        A policy waits until every linked observation has a cached value. Older input
+        snapshots are rejected; equal timestamps replace cached samples.
+        """
         results: dict[URIRef, tuple[bool, str]] = {}
         obs_by_policy: dict[URIRef, list[ObservationStamped]] = {}
         stale_policies: set[URIRef] = set()
@@ -535,6 +569,7 @@ class ObservationManager:
         return results
 
     def on_event(self, evt_uri: URIRef, evt_t: float):
+        """Record a scenario event and open or close affected fluent timelines."""
         if evt_uri not in self.event_timelines:
             self.event_timelines[evt_uri] = [evt_t]
         else:
@@ -562,6 +597,7 @@ class ObservationManager:
         bhv_loaders: list[AttrLoaderProtocol],
         obs_loaders: list[AttrLoaderProtocol],
     ) -> ObservationManager:
+        """Build a manager for a scenario variant and register its fluent policies."""
         scr_exec = ScenarioExecutionModel(
             graph=graph,
             scr_var=scr_var,

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from dataclasses import dataclass
+from inspect import isclass
 from typing import Any, Protocol
 
 from rdf_utils.models.common import AttrLoaderProtocol, ModelBase
@@ -145,6 +146,9 @@ class ObsPolicyModel(ModelBase):
         if URI_PY_TYPE_MODULE_ATTR in self.types:
             load_py_module_attr(graph=graph, model=self, quiet=False)
             evaluator = import_attr_from_model(model=self)
+            if isclass(evaluator):
+                # Stateful evaluator classes must have a no-argument constructor.
+                evaluator = evaluator()
             if not callable(evaluator):
                 raise TypeError(f"ObservationPolicy '{self.id}' Python attribute is not callable")
             self.evaluator = evaluator

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -20,6 +20,7 @@ from bdd_dsl.models.time_constraint import get_duration
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_OF_CLAUSE,
     URI_OBS_PRED_HAS_OBSERVATION,
+    URI_OBS_PRED_OBSERVES_TARGET,
     URI_OBS_PRED_PROVIDER,
     URI_OBS_TYPE_POLICY,
     URI_TIME_PRED_AFTER_EVT,
@@ -42,6 +43,16 @@ class ObservationStamped:
 
 class TimestampedObservationProtocol(Protocol):
     def __call__(self, observation: Any, receipt_stamp: float) -> float: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EntityObservation:
+    entity_uri: URIRef
+    value: Any
+
+
+class EntityObservationMapperProtocol(Protocol):
+    def __call__(self, observation: Any) -> list[EntityObservation]: ...
 
 
 class ObservationPolicyEvaluatorProtocol(Protocol):
@@ -75,6 +86,7 @@ class ObsPolicyModel(ModelBase):
     trinary_timeline: list[TrinaryStamped]
     observation_uris: set[URIRef]
     observation_providers: dict[URIRef, URIRef]
+    observation_targets: dict[URIRef, URIRef | None]
     evaluator: ObservationPolicyEvaluatorProtocol | None
 
     start_time: float | None
@@ -113,19 +125,27 @@ class ObsPolicyModel(ModelBase):
         self.trinary_timeline = []
         self.observation_uris = set()
         self.observation_providers = {}
-        for observation_uri in graph.objects(subject=self.id, predicate=URI_OBS_PRED_HAS_OBSERVATION):
+        self.observation_targets = {}
+        for observation_uri in graph.objects(
+            subject=self.id, predicate=URI_OBS_PRED_HAS_OBSERVATION
+        ):
             if not isinstance(observation_uri, URIRef):
                 raise TypeError(
                     f"ObservationPolicy '{self.id}' links to non-URI observation: {observation_uri}"
                 )
             provider_uri = graph.value(
-                subject=observation_uri, predicate=URI_OBS_PRED_PROVIDER, any=False)
+                subject=observation_uri, predicate=URI_OBS_PRED_PROVIDER, any=False
+            )
             if not isinstance(provider_uri, URIRef):
                 raise TypeError(
                     f"Observation '{observation_uri}' has invalid provider: {provider_uri}"
                 )
+            target_uri = graph.value(observation_uri, URI_OBS_PRED_OBSERVES_TARGET, any=False)
+            if target_uri is not None and not isinstance(target_uri, URIRef):
+                raise TypeError(f"Observation '{observation_uri}' has invalid target: {target_uri}")
             self.observation_uris.add(observation_uri)
             self.observation_providers[observation_uri] = provider_uri
+            self.observation_targets[observation_uri] = target_uri
 
         self.evaluator = None
         if URI_PY_TYPE_MODULE_ATTR in self.types:
@@ -314,6 +334,9 @@ class ObservationManager:
     _fluent_policy_registry: dict[URIRef, set[URIRef]]  # fluent ID -> policy IDs
     observation_cache: dict[URIRef, ObservationStamped]
     _observation_policy_registry: dict[URIRef, URIRef]  # observation ID -> policy ID
+    _provider_registry: dict[
+        URIRef, tuple[TimestampedObservationProtocol | None, EntityObservationMapperProtocol | None]
+    ]
 
     event_timelines: dict[URIRef, list[float]]
     _fluent_event_registry: dict[URIRef, set[URIRef]]  # fluent ID -> event IDs
@@ -329,6 +352,7 @@ class ObservationManager:
         self._fluent_policy_registry = {}
         self.observation_cache = {}
         self._observation_policy_registry = {}
+        self._provider_registry = {}
 
         self.event_timelines = {}
         self._fluent_event_registry = {}
@@ -384,6 +408,59 @@ class ObservationManager:
             self._register_fluent_event(evt_uri=obs_pol.start_event, fc_id=fc.id)
             self._register_fluent_event(evt_uri=obs_pol.end_event, fc_id=fc.id)
             self.obs_policies[obs_pol.id] = obs_pol
+
+    def register_provider(
+        self,
+        provider_uri: URIRef,
+        timestamp_extractor: TimestampedObservationProtocol | None = None,
+        entity_mapper: EntityObservationMapperProtocol | None = None,
+    ) -> None:
+        self._provider_registry[provider_uri] = (timestamp_extractor, entity_mapper)
+
+    def bind_observation_targets(self, bindings: dict[URIRef, Any]) -> None:
+        """Resolve template-variable targets for this scenario context."""
+        for policy in self.obs_policies.values():
+            for observation_uri, target_uri in policy.observation_targets.items():
+                bound_target = bindings.get(target_uri)
+                if bound_target is not None:
+                    if not isinstance(bound_target, URIRef):
+                        raise TypeError(
+                            f"observation target '{target_uri}' is bound to non-URI {bound_target}"
+                        )
+                    policy.observation_targets[observation_uri] = bound_target
+
+    def update_provider_observation(
+        self, provider_uri: URIRef, raw_value: Any, receipt_stamp: float
+    ) -> list[tuple[bool, str]]:
+        timestamp_extractor, entity_mapper = self._provider_registry.get(provider_uri, (None, None))
+        stamp = (
+            receipt_stamp
+            if timestamp_extractor is None
+            else timestamp_extractor(raw_value, receipt_stamp)
+        )
+        values = [(None, raw_value)]
+        if entity_mapper is not None:
+            for entity_observation in entity_mapper(raw_value):
+                if not isinstance(entity_observation, EntityObservation):
+                    raise TypeError(
+                        f"entity mapper for {provider_uri} returned {type(entity_observation)}"
+                    )
+                values.append((entity_observation.entity_uri, entity_observation.value))
+
+        results = []
+        for observation_uri, policy_uri in self._observation_policy_registry.items():
+            policy = self.obs_policies[policy_uri]
+            if policy.observation_providers[observation_uri] != provider_uri:
+                continue
+            target_uri = policy.observation_targets[observation_uri]
+            for entity_uri, value in values:
+                if entity_uri == target_uri:
+                    results.append(
+                        self.update_observation(
+                            ObservationStamped(observation_uri, provider_uri, stamp, value)
+                        )
+                    )
+        return results
 
     def update_bhv_result(self, trin_st: TrinaryStamped):
         self.bhv_result = trin_st

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -325,6 +325,7 @@ class ObservationManager:
     bhv_result: TrinaryStamped | None
 
     obs_policies: dict[URIRef, ObsPolicyModel]  # policy ID -> ObsPolicyModel
+    providers: dict[URIRef, ModelBase]
     _fluent_policy_registry: dict[URIRef, set[URIRef]]  # fluent ID -> policy IDs
     observation_cache: dict[URIRef, ObservationStamped]
     _observation_policy_registry: dict[URIRef, URIRef]  # observation ID -> policy ID
@@ -343,6 +344,7 @@ class ObservationManager:
         self.bhv_result = None
 
         self.obs_policies = {}
+        self.providers = {}
         self._fluent_policy_registry = {}
         self.observation_cache = {}
         self._observation_policy_registry = {}
@@ -399,6 +401,10 @@ class ObservationManager:
                 if obs_uri in self._observation_policy_registry:
                     raise ValueError(f"Observation already registered: '{obs_uri}'")
                 self._observation_policy_registry[obs_uri] = obs_pol.id
+            for provider_uri in set(obs_pol.observation_providers.values()):
+                self.providers.setdefault(
+                    provider_uri, ModelBase(node_id=provider_uri, graph=graph)
+                )
             self._register_fluent_event(evt_uri=obs_pol.start_event, fc_id=fc.id)
             self._register_fluent_event(evt_uri=obs_pol.end_event, fc_id=fc.id)
             self.obs_policies[obs_pol.id] = obs_pol
@@ -422,6 +428,14 @@ class ObservationManager:
                             f"observation target '{target_uri}' is bound to non-URI {bound_target}"
                         )
                     policy.observation_targets[obs_uri] = bound_target
+
+    def observation_targets_for_provider(self, provider_uri: URIRef) -> dict[URIRef, URIRef | None]:
+        return {
+            obs_uri: policy.observation_targets[obs_uri]
+            for policy in self.obs_policies.values()
+            for obs_uri, configured_provider in policy.observation_providers.items()
+            if configured_provider == provider_uri
+        }
 
     def update_provider_observation(
         self, provider_uri: URIRef, raw_value: Any, receipt_stamp: float

--- a/src/bdd_dsl/models/urirefs.py
+++ b/src/bdd_dsl/models/urirefs.py
@@ -34,13 +34,18 @@ URI_TASK_PRED_OF_TASK = NS_MM_TASK["of-task"]
 # Observation
 URI_OBS_TYPE_POLICY = NS_MM_OBS["ObservationPolicy"]
 URI_OBS_TYPE_PROVIDER = NS_MM_OBS["ObservationProvider"]
+URI_OBS_TYPE_OBSERVATION = NS_MM_OBS["Observation"]
+URI_OBS_TYPE_POSE_PROVIDER = NS_MM_OBS["PoseProvider"]
 URI_OBS_PRED_POLICY = NS_MM_OBS["has-policy"]
 URI_OBS_PRED_PROVIDER = NS_MM_OBS["has-provider"]
+URI_OBS_PRED_HAS_OBSERVATION = NS_MM_OBS["has-observation"]
+URI_OBS_PRED_OBSERVES_TARGET = NS_MM_OBS["observes-target"]
 
 # ROS
 URI_ROS_TYPE_TOPIC = NS_MM_ROS["Topic"]
 URI_ROS_TYPE_SERVICE = NS_MM_ROS["Service"]
 URI_ROS_TYPE_ACTION = NS_MM_ROS["Action"]
+URI_ROS_TYPE_SIM_ENTITY_STATE_PROVIDER = NS_MM_ROS["SimulationEntityStateProvider"]
 URI_ROS_PRED_CHNL_NAME = NS_MM_ROS["channel-name"]
 URI_ROS_PRED_TYPE_NAME = NS_MM_ROS["type-name"]
 

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -182,6 +182,8 @@ class BDDExecTest(unittest.TestCase):
         manager._observation_policy_registry.update(
             {observation_uri: policy_uri for observation_uri in observation_uris}
         )
+        manager.bind_observation_targets({None: URIRef("urn:test:must-not-bind")})
+        self.assertTrue(all(policy.observation_targets[uri] is None for uri in observation_uris))
 
         results = manager.update_observations(
             [

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -25,6 +25,7 @@ from bdd_dsl.models.observation import (
 )
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_HAS_BHV_IMPL,
+    URI_BDD_PRED_OF_SCENE,
     URI_BDD_PRED_OF_VARIANT,
     URI_BDD_TYPE_SCENARIO_EXEC,
     URI_BHV_PRED_OF_BHV,
@@ -126,41 +127,105 @@ class BDDExecTest(unittest.TestCase):
             entity_mapper=lambda _: [EntityObservation(bound_target_uri, True)],
         )
         results = manager.update_provider_observation(provider_uri, object(), 1.0)
-        self.assertEqual(results, [(True, "")])
+        self.assertEqual(results, {policy_uri: (True, "")})
         self.assertEqual(policy.trinary_timeline[0].stamp, 2.0)
         self.assertTrue(policy.trinary_timeline[0].trinary)
 
-        accepted, detail = manager.update_observation(
-            ObservationStamped(observation_uri, provider_uri, 1.0, object())
-        )
+        accepted, detail = manager.update_observations(
+            [ObservationStamped(observation_uri, provider_uri, 1.0, object())]
+        )[policy_uri]
         self.assertFalse(accepted)
         self.assertIn("older", detail)
         self.assertEqual(manager.observation_cache[observation_uri].stamp, 2.0)
         self.assertEqual(len(policy.trinary_timeline), 1)
 
         with self.assertRaisesRegex(ValueError, "expected"):
-            manager.update_observation(
-                ObservationStamped(
-                    observation_uri, URIRef("urn:test:wrong-provider"), 3.0, object()
-                )
+            manager.update_observations(
+                [
+                    ObservationStamped(
+                        observation_uri, URIRef("urn:test:wrong-provider"), 3.0, object()
+                    )
+                ]
             )
+
+    def test_observation_batch_evaluates_policy_once_after_caching_all_samples(self):
+        graph = Graph()
+        policy_uri = URIRef("urn:test:policy")
+        provider_uri = URIRef("urn:test:provider")
+        observation_uris = [URIRef(f"urn:test:observation-{i}") for i in range(2)]
+        graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
+        for observation_uri in observation_uris:
+            graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
+            graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
+            graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
+
+        policy = ObsPolicyModel(
+            node_id=policy_uri,
+            graph=graph,
+            fluent_id=URIRef("urn:test:fluent"),
+            fluent_types=set(),
+            duration_type=URI_TIME_TYPE_BEFORE_EVT,
+            start_event=None,
+            end_event=URIRef("urn:test:end"),
+            horizon=10.0,
+        )
+        calls = []
+        policy.evaluator = lambda samples: calls.append(samples) or True
+        manager = ObservationManager(scr_exec=SimpleNamespace())
+        manager.obs_policies[policy_uri] = policy
+        manager._observation_policy_registry.update(
+            {observation_uri: policy_uri for observation_uri in observation_uris}
+        )
+
+        results = manager.update_observations(
+            [
+                ObservationStamped(observation_uri, provider_uri, stamp, True)
+                for observation_uri, stamp in zip(observation_uris, (1.0, 2.0), strict=True)
+            ]
+        )
+
+        self.assertEqual(results, {policy_uri: (True, "")})
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(policy.trinary_timeline[-1].stamp, 2.0)
+
+        cached_snapshot = dict(manager.observation_cache)
+        results = manager.update_observations(
+            [
+                ObservationStamped(observation_uris[0], provider_uri, 0.0, False),
+                ObservationStamped(observation_uris[1], provider_uri, 3.0, False),
+            ]
+        )
+
+        self.assertEqual(
+            results,
+            {policy_uri: (False, "(observation) older than cached sample")},
+        )
+        self.assertEqual(manager.observation_cache, cached_snapshot)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(policy.trinary_timeline), 1)
 
     def test_scenario_execution_selects_exact_scene_instance(self):
         graph = Graph()
         variant = URIRef("urn:test:variant")
         execution = URIRef("urn:test:execution")
         scene_inst = URIRef("urn:test:scene-instance")
+        scene = URIRef("urn:test:scene")
         bhv_impl = URIRef("urn:test:behaviour-implementation")
         behaviour = URIRef("urn:test:behaviour")
         graph.add((execution, RDF.type, URI_BDD_TYPE_SCENARIO_EXEC))
         graph.add((execution, URI_BDD_PRED_OF_VARIANT, variant))
         graph.add((execution, URI_EXEC_PRED_RUNS_SCENE, scene_inst))
         graph.add((scene_inst, RDF.type, URI_EXEC_TYPE_SCENE_INST))
+        graph.add((scene_inst, URI_BDD_PRED_OF_SCENE, scene))
         graph.add((execution, URI_BDD_PRED_HAS_BHV_IMPL, bhv_impl))
         graph.add((bhv_impl, RDF.type, URIRef("urn:test:Implementation")))
         graph.add((bhv_impl, URI_BHV_PRED_OF_BHV, behaviour))
         graph.add((behaviour, RDF.type, URIRef("urn:test:Behaviour")))
-        scr_var = SimpleNamespace(id=variant, tmpl=object())
+        scr_var = SimpleNamespace(
+            id=variant,
+            tmpl=object(),
+            scene=SimpleNamespace(id=scene),
+        )
         duration = {
             URI_TIME_PRED_AFTER_EVT: URIRef("urn:test:start"),
             URI_TIME_PRED_BEFORE_EVT: URIRef("urn:test:end"),
@@ -168,7 +233,7 @@ class BDDExecTest(unittest.TestCase):
 
         with patch("bdd_dsl.execution.scenario.get_duration", return_value=duration):
             model = ScenarioExecutionModel(graph, scr_var, bhv_loaders=[])
-            self.assertEqual(model.scene_inst_id, scene_inst)
+            self.assertEqual(model.scene_instance.id, scene_inst)
 
             other_scene = URIRef("urn:test:other-scene-instance")
             graph.add((other_scene, RDF.type, URI_EXEC_TYPE_SCENE_INST))

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -103,6 +103,7 @@ class BDDExecTest(unittest.TestCase):
         graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
         graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
         graph.add((observation_uri, URI_OBS_PRED_OBSERVES_TARGET, target_uri))
+        graph.add((provider_uri, RDF.type, URIRef("urn:test:provider-type")))
 
         policy = ObsPolicyModel(
             node_id=policy_uri,
@@ -115,12 +116,17 @@ class BDDExecTest(unittest.TestCase):
             horizon=10.0,
         )
         self.assertEqual(policy.observation_targets[observation_uri], target_uri)
-        manager = ObservationManager(scr_exec=SimpleNamespace())
-        manager.obs_policies[policy_uri] = policy
-        manager._observation_policy_registry[observation_uri] = policy_uri
+        manager = ObservationManager(scr_exec=SimpleNamespace(obs_policy_uris={policy_uri}))
+        with patch.object(ObsPolicyModel, "policies_for_fluent_clause", return_value=[policy]):
+            manager.register_fluent_obs(graph, SimpleNamespace(id=policy.fluent_id), obs_loaders=[])
+        self.assertEqual(manager.providers[provider_uri].id, provider_uri)
 
         manager.bind_observation_targets({target_uri: bound_target_uri})
         self.assertEqual(policy.observation_targets[observation_uri], bound_target_uri)
+        self.assertEqual(
+            manager.observation_targets_for_provider(provider_uri),
+            {observation_uri: bound_target_uri},
+        )
         manager.register_provider(
             provider_uri,
             timestamp_extractor=lambda _, receipt_stamp: receipt_stamp + 1,

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -17,13 +17,19 @@ from rdflib import RDF, Dataset, Graph, Literal, URIRef
 
 from bdd_dsl.execution.common import URL_MM_EXEC_SHACL
 from bdd_dsl.execution.scenario import ScenarioExecutionModel
-from bdd_dsl.models.observation import ObsPolicyModel, ObservationManager, ObservationStamped
+from bdd_dsl.models.observation import (
+    EntityObservation,
+    ObservationManager,
+    ObservationStamped,
+    ObsPolicyModel,
+)
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_HAS_BHV_IMPL,
     URI_BDD_PRED_OF_VARIANT,
     URI_BDD_TYPE_SCENARIO_EXEC,
     URI_BHV_PRED_OF_BHV,
     URI_OBS_PRED_HAS_OBSERVATION,
+    URI_OBS_PRED_OBSERVES_TARGET,
     URI_OBS_PRED_PROVIDER,
     URI_OBS_TYPE_OBSERVATION,
     URI_OBS_TYPE_POLICY,
@@ -86,6 +92,8 @@ class BDDExecTest(unittest.TestCase):
         policy_uri = URIRef("urn:test:policy")
         observation_uri = URIRef("urn:test:observation")
         provider_uri = URIRef("urn:test:provider")
+        target_uri = URIRef("urn:test:target-variable")
+        bound_target_uri = URIRef("urn:test:target")
         graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
         graph.add((policy_uri, RDF.type, URI_PY_TYPE_MODULE_ATTR))
         graph.add((policy_uri, URI_PY_PRED_MODULE_NAME, Literal("operator")))
@@ -93,6 +101,7 @@ class BDDExecTest(unittest.TestCase):
         graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
         graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
         graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
+        graph.add((observation_uri, URI_OBS_PRED_OBSERVES_TARGET, target_uri))
 
         policy = ObsPolicyModel(
             node_id=policy_uri,
@@ -104,14 +113,20 @@ class BDDExecTest(unittest.TestCase):
             end_event=URIRef("urn:test:end"),
             horizon=10.0,
         )
+        self.assertEqual(policy.observation_targets[observation_uri], target_uri)
         manager = ObservationManager(scr_exec=SimpleNamespace())
         manager.obs_policies[policy_uri] = policy
         manager._observation_policy_registry[observation_uri] = policy_uri
 
-        accepted, _ = manager.update_observation(
-            ObservationStamped(observation_uri, provider_uri, 2.0, object())
+        manager.bind_observation_targets({target_uri: bound_target_uri})
+        self.assertEqual(policy.observation_targets[observation_uri], bound_target_uri)
+        manager.register_provider(
+            provider_uri,
+            timestamp_extractor=lambda _, receipt_stamp: receipt_stamp + 1,
+            entity_mapper=lambda _: [EntityObservation(bound_target_uri, True)],
         )
-        self.assertTrue(accepted)
+        results = manager.update_provider_observation(provider_uri, object(), 1.0)
+        self.assertEqual(results, [(True, "")])
         self.assertEqual(policy.trinary_timeline[0].stamp, 2.0)
         self.assertTrue(policy.trinary_timeline[0].trinary)
 
@@ -125,7 +140,9 @@ class BDDExecTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "expected"):
             manager.update_observation(
-                ObservationStamped(observation_uri, URIRef("urn:test:wrong-provider"), 3.0, object())
+                ObservationStamped(
+                    observation_uri, URIRef("urn:test:wrong-provider"), 3.0, object()
+                )
             )
 
     def test_scenario_execution_selects_exact_scene_instance(self):

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -210,6 +210,47 @@ class BDDExecTest(unittest.TestCase):
         self.assertEqual(len(calls), 1)
         self.assertEqual(len(policy.trinary_timeline), 1)
 
+    def test_python_observation_policy_instantiates_callable_class_once(self):
+        class StatefulEvaluator:
+            def __init__(self):
+                self.calls = 0
+
+            def __call__(self, observations):
+                self.calls += 1
+                return bool(observations)
+
+        graph = Graph()
+        policy_uri = URIRef("urn:test:policy")
+        observation_uri = URIRef("urn:test:observation")
+        provider_uri = URIRef("urn:test:provider")
+        graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
+        graph.add((policy_uri, RDF.type, URI_PY_TYPE_MODULE_ATTR))
+        graph.add((policy_uri, URI_PY_PRED_MODULE_NAME, Literal("operator")))
+        graph.add((policy_uri, URI_PY_PRED_ATTR_NAME, Literal("truth")))
+        graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
+        graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
+        graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
+
+        with patch(
+            "bdd_dsl.models.observation.import_attr_from_model", return_value=StatefulEvaluator
+        ):
+            policy = ObsPolicyModel(
+                node_id=policy_uri,
+                graph=graph,
+                fluent_id=URIRef("urn:test:fluent"),
+                fluent_types=set(),
+                duration_type=URI_TIME_TYPE_BEFORE_EVT,
+                start_event=None,
+                end_event=URIRef("urn:test:end"),
+                horizon=10.0,
+            )
+
+        self.assertIsInstance(policy.evaluator, StatefulEvaluator)
+        sample = ObservationStamped(observation_uri, provider_uri, 1.0, True)
+        self.assertTrue(policy.evaluator([sample]))
+        self.assertTrue(policy.evaluator([sample]))
+        self.assertEqual(policy.evaluator.calls, 2)
+
     def test_scenario_execution_selects_exact_scene_instance(self):
         graph = Graph()
         variant = URIRef("urn:test:variant")

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -5,20 +5,31 @@ from unittest.mock import patch
 from urllib.request import HTTPError
 
 from rdf_utils.constraints import check_shacl_constraints
+from rdf_utils.models.python import (
+    URI_PY_PRED_ATTR_NAME,
+    URI_PY_PRED_MODULE_NAME,
+    URI_PY_TYPE_MODULE_ATTR,
+)
 from rdf_utils.models.vocab import URI_EXEC_PRED_RUNS_SCENE, URI_EXEC_TYPE_SCENE_INST
 from rdf_utils.namespace import URL_MM_PYTHON_SHACL, URL_SECORO_M
 from rdf_utils.resolver import install_resolver
-from rdflib import RDF, Dataset, Graph, URIRef
+from rdflib import RDF, Dataset, Graph, Literal, URIRef
 
 from bdd_dsl.execution.common import URL_MM_EXEC_SHACL
 from bdd_dsl.execution.scenario import ScenarioExecutionModel
+from bdd_dsl.models.observation import ObsPolicyModel, ObservationManager, ObservationStamped
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_HAS_BHV_IMPL,
     URI_BDD_PRED_OF_VARIANT,
     URI_BDD_TYPE_SCENARIO_EXEC,
     URI_BHV_PRED_OF_BHV,
+    URI_OBS_PRED_HAS_OBSERVATION,
+    URI_OBS_PRED_PROVIDER,
+    URI_OBS_TYPE_OBSERVATION,
+    URI_OBS_TYPE_POLICY,
     URI_TIME_PRED_AFTER_EVT,
     URI_TIME_PRED_BEFORE_EVT,
+    URI_TIME_TYPE_BEFORE_EVT,
 )
 from bdd_dsl.models.user_story import UserStoryLoader
 
@@ -69,6 +80,53 @@ class BDDExecTest(unittest.TestCase):
                     full_graph=self.graph, variant_id=scr_var_uri
                 )
                 self.assertTrue(scr_var.scene.objects)
+
+    def test_python_observation_policy_evaluates_cached_samples(self):
+        graph = Graph()
+        policy_uri = URIRef("urn:test:policy")
+        observation_uri = URIRef("urn:test:observation")
+        provider_uri = URIRef("urn:test:provider")
+        graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
+        graph.add((policy_uri, RDF.type, URI_PY_TYPE_MODULE_ATTR))
+        graph.add((policy_uri, URI_PY_PRED_MODULE_NAME, Literal("operator")))
+        graph.add((policy_uri, URI_PY_PRED_ATTR_NAME, Literal("truth")))
+        graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
+        graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
+        graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
+
+        policy = ObsPolicyModel(
+            node_id=policy_uri,
+            graph=graph,
+            fluent_id=URIRef("urn:test:fluent"),
+            fluent_types=set(),
+            duration_type=URI_TIME_TYPE_BEFORE_EVT,
+            start_event=None,
+            end_event=URIRef("urn:test:end"),
+            horizon=10.0,
+        )
+        manager = ObservationManager(scr_exec=SimpleNamespace())
+        manager.obs_policies[policy_uri] = policy
+        manager._observation_policy_registry[observation_uri] = policy_uri
+
+        accepted, _ = manager.update_observation(
+            ObservationStamped(observation_uri, provider_uri, 2.0, object())
+        )
+        self.assertTrue(accepted)
+        self.assertEqual(policy.trinary_timeline[0].stamp, 2.0)
+        self.assertTrue(policy.trinary_timeline[0].trinary)
+
+        accepted, detail = manager.update_observation(
+            ObservationStamped(observation_uri, provider_uri, 1.0, object())
+        )
+        self.assertFalse(accepted)
+        self.assertIn("older", detail)
+        self.assertEqual(manager.observation_cache[observation_uri].stamp, 2.0)
+        self.assertEqual(len(policy.trinary_timeline), 1)
+
+        with self.assertRaisesRegex(ValueError, "expected"):
+            manager.update_observation(
+                ObservationStamped(observation_uri, URIRef("urn:test:wrong-provider"), 3.0, object())
+            )
 
     def test_scenario_execution_selects_exact_scene_instance(self):
         graph = Graph()


### PR DESCRIPTION
## Summary

Add provider-backed observation evaluation to bdd-dsl while preserving legacy trinary-topic policies.

## Changes

- Add normalized observation runtime contracts:
    - `ObservationStamped`
    - timestamp extraction
    - entity mapping
    - policy evaluation protocols.
- Extend `ObsPolicyModel` with policy-local observations, providers, targets, evaluators, and cached samples.
- Add `ObservationManager` provider routing:
    - provider adapter registration;
    - scenario target binding;
    - raw-message normalization;
    - atomic multi-observation caching;
    - stale-sample rejection;
    - timestamped trinary timeline updates.
- Support Python evaluators as functions, callable objects, or no-argument callable classes instantiated once per policy context.
- Keep direct `TrinaryStamped` policy assertions as the compatibility path.
- Resolve and retain the concrete `SceneInstanceModel` on `ScenarioExecutionModel`.
- Add API doc strings for observation and scenario execution behavior.
- Add regression coverage for caching, timestamps, target mapping, stale samples, provider validation, callable evaluator classes, scene-instance selection, and targetless observations.

## Related

- Tested with RDF generated with new syntax in minhnh/robbdd#19
- Depends on SHACL & metamodel updates in minhnh/metamodels-bdd#9
- Time keeping for observations and policies are tested in minhnh/bdd_exec_ros2#6