### PR TITLE
Change observation policy evaluators to abstract classes

### DIFF
--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -63,36 +63,45 @@ class EntityObservationMapperProtocol(Protocol):
 
 
 class ObservationPolicyEvaluatorProtocol(Protocol):
-    """Evaluate a complete policy snapshot as a trinary or boolean.
+    """Evaluate a complete policy snapshot as a value and human-readable reason.
 
     A Python policy attribute may be a function, a callable object, or a no-argument
     callable class. Classes are instantiated once while the policy model is loaded.
     """
 
-    def __call__(self, observations: list[ObservationStamped]) -> bool | Trinary: ...
+    def __call__(self, observations: list[ObservationStamped]) -> tuple[bool | Trinary, str]: ...
 
 
 @dataclass(frozen=True, slots=True)
 class TrinaryStamped:
     stamp: float
     trinary: Trinary | bool
+    reason: str = ""
 
 
 class TrinariesPolicyProtocol(Protocol):
     """Protocol for functions that load model attributes."""
 
-    def __call__(self, trinaries: list[TrinaryStamped], **kwargs: Any) -> bool | Trinary: ...
+    def __call__(
+        self, trinaries: list[TrinaryStamped], **kwargs: Any
+    ) -> tuple[bool | Trinary, str]: ...
 
 
-def trin_policy_and(trinaries: list[TrinaryStamped], **kwargs: Any) -> bool | Trinary:
+def trin_policy_and(trinaries: list[TrinaryStamped], **kwargs: Any) -> tuple[bool | Trinary, str]:
     if len(trinaries) == 0:
-        return Unknown
+        return Unknown, "no trinary assertions"
 
     result = True
     for trin_st in trinaries:
         result &= trin_st.trinary
 
-    return result
+    if result is False:
+        reason = "at least one assertion is false"
+    elif result is Unknown:
+        reason = "at least one assertion is unknown"
+    else:
+        reason = "all assertions are true"
+    return result, reason
 
 
 class ObsPolicyModel(ModelBase):
@@ -565,8 +574,15 @@ class ObservationManager:
 
             samples = [self.observation_cache[uri] for uri in policy.observation_uris]
             result = policy.evaluator(samples)
+            if not isinstance(result, tuple) or len(result) != 2 or not isinstance(result[1], str):
+                raise TypeError("observation evaluator must return (trinary, reason)")
+            trinary, reason = result
             results[policy_uri] = policy.add_trinary(
-                TrinaryStamped(stamp=max(sample.stamp for sample in samples), trinary=result)
+                TrinaryStamped(
+                    stamp=max(sample.stamp for sample in samples),
+                    trinary=trinary,
+                    reason=reason,
+                )
             )
         return results
 

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -13,6 +13,7 @@ from rdf_utils.models.python import (
     load_py_module_attr,
 )
 from rdflib import Graph, URIRef
+from scene_dsl.rdf_parser.scenex import SceneInstanceModel
 from trinary import Trinary, Unknown
 
 from bdd_dsl.execution.scenario import ScenarioExecutionModel
@@ -57,9 +58,14 @@ class EntityObservation:
 
 
 class EntityObservationMapperProtocol(Protocol):
-    """Map a raw provider message to zero or more target-specific values."""
+    """Map a raw provider message using the active scenario scene."""
 
-    def __call__(self, observation: Any) -> list[EntityObservation]: ...
+    def __call__(
+        self,
+        observation: Any,
+        scene_instance: SceneInstanceModel,
+        targets: list[URIRef],
+    ) -> list[EntityObservation]: ...
 
 
 class ObservationPolicyEvaluatorProtocol(Protocol):
@@ -491,7 +497,14 @@ class ObservationManager:
         )
         values: list[tuple[URIRef | None, Any]] = [(None, raw_value)]
         if entity_mapper is not None:
-            for entity_obs in entity_mapper(raw_value):
+            targets = list(
+                dict.fromkeys(
+                    target
+                    for target in self.observation_targets_for_provider(provider_uri).values()
+                    if target is not None
+                )
+            )
+            for entity_obs in entity_mapper(raw_value, self.scenario_exec.scene_instance, targets):
                 if not isinstance(entity_obs, EntityObservation):
                     raise TypeError(f"entity mapper for {provider_uri} returned {type(entity_obs)}")
                 values.append((entity_obs.entity_uri, entity_obs.value))

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Generator
 from dataclasses import dataclass
 from inspect import isclass
@@ -68,14 +69,27 @@ class EntityObservationMapperProtocol(Protocol):
     ) -> list[EntityObservation]: ...
 
 
-class ObservationPolicyEvaluatorProtocol(Protocol):
-    """Evaluate a complete policy snapshot as a value and human-readable reason.
+class ObservationPolicyEvaluator(ABC):
+    """Base evaluator with a result for an empty observation set."""
 
-    A Python policy attribute may be a function, a callable object, or a no-argument
-    callable class. Classes are instantiated once while the policy model is loaded.
-    """
+    def __init__(
+        self,
+        default_result: tuple[bool | Trinary, str] = (Unknown, "no observations"),
+    ) -> None:
+        self.default_result = default_result
 
-    def __call__(self, observations: list[ObservationStamped]) -> tuple[bool | Trinary, str]: ...
+    def evaluate(self, observations: list[ObservationStamped]) -> tuple[bool | Trinary, str]:
+        if not observations:
+            return self.default_result
+        result = self._evaluate_samples(observations)
+        if not isinstance(result, tuple) or len(result) != 2 or not isinstance(result[1], str):
+            raise TypeError("observation evaluator must return (trinary, reason)")
+        return result
+
+    @abstractmethod
+    def _evaluate_samples(
+        self, observations: list[ObservationStamped]
+    ) -> tuple[bool | Trinary, str]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,7 +129,7 @@ class ObsPolicyModel(ModelBase):
     observation_uris: set[URIRef]
     observation_providers: dict[URIRef, URIRef]
     observation_targets: dict[URIRef, URIRef | None]
-    evaluator: ObservationPolicyEvaluatorProtocol | None
+    evaluator: ObservationPolicyEvaluator | None
 
     start_time: float | None
     end_time: float | None
@@ -176,8 +190,11 @@ class ObsPolicyModel(ModelBase):
             if isclass(evaluator):
                 # Stateful evaluator classes must have a no-argument constructor.
                 evaluator = evaluator()
-            if not callable(evaluator):
-                raise TypeError(f"ObservationPolicy '{self.id}' Python attribute is not callable")
+            if not isinstance(evaluator, ObservationPolicyEvaluator):
+                raise TypeError(
+                    f"ObservationPolicy '{self.id}' Python attribute must be an "
+                    "ObservationPolicyEvaluator class"
+                )
             self.evaluator = evaluator
 
         self.start_time = None
@@ -261,6 +278,34 @@ class ObsPolicyModel(ModelBase):
             return True, ""
 
         return False, "no matching type"
+
+    def add_samples(self, samples: list[ObservationStamped]) -> tuple[bool, str]:
+        if self.evaluator is None:
+            return False, "no evaluator"
+        if not samples:
+            return False, "no samples"
+        result = self.evaluator.evaluate(samples)
+        trinary, reason = result
+        return self.add_trinary(
+            TrinaryStamped(
+                stamp=max(sample.stamp for sample in samples),
+                trinary=trinary,
+                reason=reason,
+            )
+        )
+
+    def get_result(
+        self,
+        stamp: float,
+        trinaries_policy: TrinariesPolicyProtocol,
+    ) -> TrinaryStamped:
+        if self.trinary_timeline:
+            trinary, reason = trinaries_policy(self.trinary_timeline)
+        elif self.evaluator is None:
+            trinary, reason = Unknown, "no evaluator"
+        else:
+            trinary, reason = self.evaluator.evaluate([])
+        return TrinaryStamped(stamp=stamp, trinary=trinary, reason=reason)
 
     def on_event(self, evt_uri: URIRef, evt_stamp: float):
         if evt_uri == self.start_event:
@@ -578,25 +623,12 @@ class ObservationManager:
                 self.observation_cache[obs.observation_uri] = obs
 
             policy = self.obs_policies[policy_uri]
-            if policy.evaluator is None:
-                results[policy_uri] = (False, "no evaluator")
-                continue
             if any(uri not in self.observation_cache for uri in policy.observation_uris):
                 results[policy_uri] = (True, "(observation) waiting for policy inputs")
                 continue
 
             samples = [self.observation_cache[uri] for uri in policy.observation_uris]
-            result = policy.evaluator(samples)
-            if not isinstance(result, tuple) or len(result) != 2 or not isinstance(result[1], str):
-                raise TypeError("observation evaluator must return (trinary, reason)")
-            trinary, reason = result
-            results[policy_uri] = policy.add_trinary(
-                TrinaryStamped(
-                    stamp=max(sample.stamp for sample in samples),
-                    trinary=trinary,
-                    reason=reason,
-                )
-            )
+            results[policy_uri] = policy.add_samples(samples)
         return results
 
     def on_event(self, evt_uri: URIRef, evt_t: float):

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -20,6 +20,7 @@ from bdd_dsl.execution.scenario import ScenarioExecutionModel
 from bdd_dsl.models.observation import (
     EntityObservation,
     ObservationManager,
+    ObservationPolicyEvaluator,
     ObservationStamped,
     ObsPolicyModel,
     TrinaryStamped,
@@ -63,6 +64,49 @@ def test_trinary_policy_and_reports_final_result():
 
     assert value is False
     assert reason == "at least one assertion is false"
+
+
+def test_default_observation_evaluator_handles_empty_and_non_empty_samples():
+    class Evaluator(ObservationPolicyEvaluator):
+        def _evaluate_samples(self, observations):
+            return False, f"{len(observations)} samples"
+
+    evaluator = Evaluator((True, "no collision recorded"))
+    assert evaluator.evaluate([]) == (True, "no collision recorded")
+    assert evaluator.evaluate(
+        [ObservationStamped(URIRef("urn:test:obs"), URIRef("urn:test:provider"), 1.0, True)]
+    ) == (False, "1 samples")
+
+
+def test_policy_result_uses_default_until_an_accepted_sample_exists():
+    policy_uri = URIRef("urn:test:policy-default")
+    graph = Graph()
+    graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
+    policy = ObsPolicyModel(
+        node_id=policy_uri,
+        graph=graph,
+        fluent_id=URIRef("urn:test:fluent-default"),
+        fluent_types=set(),
+        duration_type=URI_TIME_TYPE_BEFORE_EVT,
+        start_event=None,
+        end_event=URIRef("urn:test:end-default"),
+        horizon=10.0,
+    )
+
+    class Evaluator(ObservationPolicyEvaluator):
+        def _evaluate_samples(self, observations):
+            return False, "collision recorded"
+
+    policy.evaluator = Evaluator((True, "no collision recorded"))
+    assert policy.get_result(1.0, trin_policy_and).trinary is True
+
+    accepted, _ = policy.add_samples(
+        [ObservationStamped(URIRef("urn:test:obs"), URIRef("urn:test:provider"), 2.0, True)]
+    )
+    assert accepted
+    result = policy.get_result(2.0, trin_policy_and)
+    assert result.trinary is False
+    assert result.reason == "at least one assertion is false"
 
 
 EXEC_MODEL_URLS = {
@@ -113,9 +157,6 @@ class BDDExecTest(unittest.TestCase):
         target_uri = URIRef("urn:test:target-variable")
         bound_target_uri = URIRef("urn:test:target")
         graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
-        graph.add((policy_uri, RDF.type, URI_PY_TYPE_MODULE_ATTR))
-        graph.add((policy_uri, URI_PY_PRED_MODULE_NAME, Literal("operator")))
-        graph.add((policy_uri, URI_PY_PRED_ATTR_NAME, Literal("truth")))
         graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
         graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
         graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
@@ -132,7 +173,12 @@ class BDDExecTest(unittest.TestCase):
             end_event=URIRef("urn:test:end"),
             horizon=10.0,
         )
-        policy.evaluator = lambda samples: (bool(samples), "sample exists")
+
+        class TruthEvaluator(ObservationPolicyEvaluator):
+            def _evaluate_samples(self, samples):
+                return bool(samples), "sample exists"
+
+        policy.evaluator = TruthEvaluator()
         self.assertEqual(policy.observation_targets[observation_uri], target_uri)
         manager = ObservationManager(
             scr_exec=SimpleNamespace(obs_policy_uris={policy_uri}, scene_instance=None)
@@ -196,7 +242,13 @@ class BDDExecTest(unittest.TestCase):
             horizon=10.0,
         )
         calls = []
-        policy.evaluator = lambda samples: calls.append(samples) or (True, "batch complete")
+
+        class BatchEvaluator(ObservationPolicyEvaluator):
+            def _evaluate_samples(self, samples):
+                calls.append(samples)
+                return True, "batch complete"
+
+        policy.evaluator = BatchEvaluator()
         manager = ObservationManager(scr_exec=SimpleNamespace())
         manager.obs_policies[policy_uri] = policy
         manager._observation_policy_registry.update(
@@ -233,11 +285,12 @@ class BDDExecTest(unittest.TestCase):
         self.assertEqual(len(policy.trinary_timeline), 1)
 
     def test_python_observation_policy_instantiates_callable_class_once(self):
-        class StatefulEvaluator:
+        class StatefulEvaluator(ObservationPolicyEvaluator):
             def __init__(self):
+                super().__init__()
                 self.calls = 0
 
-            def __call__(self, observations):
+            def _evaluate_samples(self, observations):
                 self.calls += 1
                 return bool(observations), "stateful sample exists"
 
@@ -269,8 +322,8 @@ class BDDExecTest(unittest.TestCase):
 
         self.assertIsInstance(policy.evaluator, StatefulEvaluator)
         sample = ObservationStamped(observation_uri, provider_uri, 1.0, True)
-        self.assertTrue(policy.evaluator([sample])[0])
-        self.assertTrue(policy.evaluator([sample])[0])
+        self.assertTrue(policy.evaluator.evaluate([sample])[0])
+        self.assertTrue(policy.evaluator.evaluate([sample])[0])
         self.assertEqual(policy.evaluator.calls, 2)
 
     def test_scenario_execution_selects_exact_scene_instance(self):

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -134,7 +134,9 @@ class BDDExecTest(unittest.TestCase):
         )
         policy.evaluator = lambda samples: (bool(samples), "sample exists")
         self.assertEqual(policy.observation_targets[observation_uri], target_uri)
-        manager = ObservationManager(scr_exec=SimpleNamespace(obs_policy_uris={policy_uri}))
+        manager = ObservationManager(
+            scr_exec=SimpleNamespace(obs_policy_uris={policy_uri}, scene_instance=None)
+        )
         with patch.object(ObsPolicyModel, "policies_for_fluent_clause", return_value=[policy]):
             manager.register_fluent_obs(graph, SimpleNamespace(id=policy.fluent_id), obs_loaders=[])
         self.assertEqual(manager.providers[provider_uri].id, provider_uri)
@@ -148,7 +150,7 @@ class BDDExecTest(unittest.TestCase):
         manager.register_provider(
             provider_uri,
             timestamp_extractor=lambda _, receipt_stamp: receipt_stamp + 1,
-            entity_mapper=lambda _: [EntityObservation(bound_target_uri, True)],
+            entity_mapper=lambda _, __, ___: [EntityObservation(bound_target_uri, True)],
         )
         results = manager.update_provider_observation(provider_uri, object(), 1.0)
         self.assertEqual(results, {policy_uri: (True, "")})

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -22,6 +22,8 @@ from bdd_dsl.models.observation import (
     ObservationManager,
     ObservationStamped,
     ObsPolicyModel,
+    TrinaryStamped,
+    trin_policy_and,
 )
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_HAS_BHV_IMPL,
@@ -48,6 +50,21 @@ SPEC_MODEL_URLS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/templates/pickplace.tmpl.json": "json-ld",
     f"{URL_SECORO_M}/acceptance-criteria/bdd/variations/pickplace-secorolab-isaac.var.json": "json-ld",
 }
+
+
+def test_trinary_policy_and_reports_final_result():
+    value, reason = trin_policy_and(
+        [
+            TrinaryStamped(1.0, False, "object is not at pick workspace"),
+            TrinaryStamped(2.0, False, "object collides with place workspace"),
+            TrinaryStamped(3.0, True, "ignored success"),
+        ]
+    )
+
+    assert value is False
+    assert reason == "at least one assertion is false"
+
+
 EXEC_MODEL_URLS = {
     f"{URL_SECORO_M}/acceptance-criteria/bdd/simulation/secorolab-isaac.sim.json": "json-ld",
     f"{URL_SECORO_M}/acceptance-criteria/bdd/execution/pickplace-secorolab-isaac.exec.json": "json-ld",
@@ -115,6 +132,7 @@ class BDDExecTest(unittest.TestCase):
             end_event=URIRef("urn:test:end"),
             horizon=10.0,
         )
+        policy.evaluator = lambda samples: (bool(samples), "sample exists")
         self.assertEqual(policy.observation_targets[observation_uri], target_uri)
         manager = ObservationManager(scr_exec=SimpleNamespace(obs_policy_uris={policy_uri}))
         with patch.object(ObsPolicyModel, "policies_for_fluent_clause", return_value=[policy]):
@@ -176,7 +194,7 @@ class BDDExecTest(unittest.TestCase):
             horizon=10.0,
         )
         calls = []
-        policy.evaluator = lambda samples: calls.append(samples) or True
+        policy.evaluator = lambda samples: calls.append(samples) or (True, "batch complete")
         manager = ObservationManager(scr_exec=SimpleNamespace())
         manager.obs_policies[policy_uri] = policy
         manager._observation_policy_registry.update(
@@ -219,7 +237,7 @@ class BDDExecTest(unittest.TestCase):
 
             def __call__(self, observations):
                 self.calls += 1
-                return bool(observations)
+                return bool(observations), "stateful sample exists"
 
         graph = Graph()
         policy_uri = URIRef("urn:test:policy")
@@ -249,8 +267,8 @@ class BDDExecTest(unittest.TestCase):
 
         self.assertIsInstance(policy.evaluator, StatefulEvaluator)
         sample = ObservationStamped(observation_uri, provider_uri, 1.0, True)
-        self.assertTrue(policy.evaluator([sample]))
-        self.assertTrue(policy.evaluator([sample]))
+        self.assertTrue(policy.evaluator([sample])[0])
+        self.assertTrue(policy.evaluator([sample])[0])
         self.assertEqual(policy.evaluator.calls, 2)
 
     def test_scenario_execution_selects_exact_scene_instance(self):


### PR DESCRIPTION
## Summary

Standardize observation policy evaluation around class-based evaluators with policy-owned result handling.

## Changes

- Replace `ObservationPolicyEvaluatorProtocol` with the abstract `ObservationPolicyEvaluator` base class.
- Add `evaluate()` with configurable empty-sample defaults and `_evaluate_samples()` for concrete implementations.
- Require Python observation policies to use evaluator classes.
- Add `ObsPolicyModel.add_samples()` and `get_result()` APIs.
- Preserve observation timeline, timestamp, horizon, and rejected-sample behavior.
- Forward `SceneInstance` & mapped target URIs to `EntityObservationMapperProtocol`
- Update bdd-dsl tests for default results, accepted samples, and stateful evaluators.

## Related

- Trinary reasoning matches minhnh/bdd_ros2_interfaces#1
- Tested with minhnh/bdd_exec_ros2#7