### PR TITLE
feat(observation): load typed evaluators and fix policy horizon freshness issues

### DIFF
--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -406,21 +406,21 @@ class ObsPolicyModel(ModelBase):
         # Insert at beginning if smallest
         self.trinary_timeline.insert(0, trin_st)
 
-    def _discard_out_of_horizon_trin(self):
+    def _discard_out_of_horizon_trin(self, reference_stamp: float | None = None):
         """Clean up trinary queue for BeforeEvent type.
 
-        Discard TrinaryStamped objects outside of the time horizon, calculated either
-        from the end event or the latest TrinaryStamped instance.
+        Discard TrinaryStamped objects outside of the time horizon relative to an
+        explicit reference, the end event, or the latest TrinaryStamped instance.
         """
-        if len(self.trinary_timeline) < 1 or self.end_time is not None:
-            # if no trinary registered or timeline finished
+        if not self.trinary_timeline:
+            # if no trinary registered
             return
 
         assert self.horizon is not None, (
             f"{self.fluent_id}: _discard_out_of_horizon_trin called with no horizon specified for type: {self.duration_type}"
         )
 
-        end_t = self.end_time
+        end_t = reference_stamp if reference_stamp is not None else self.end_time
         if end_t is None:
             end_t = self.trinary_timeline[-1].stamp
 
@@ -495,6 +495,9 @@ class ObsPolicyModel(ModelBase):
         stamp: float,
         trinaries_policy: TrinariesPolicyProtocol,
     ) -> TrinaryStamped:
+        if self.duration_type == URI_TIME_TYPE_BEFORE_EVT and self.end_time is None:
+            self._discard_out_of_horizon_trin(stamp)
+
         if self.trinary_timeline:
             trinary, reason = trinaries_policy(self.trinary_timeline)
         elif self.evaluator is None:
@@ -766,6 +769,9 @@ class ObservationManager:
 
         A policy waits until every linked observation has a cached value. Older input
         snapshots are rejected; equal timestamps replace cached samples.
+        The returned dictionary maps each represented policy URI to an
+        (accepted, reason) update outcome. The accepted flag reports whether the
+        update was handled; it is not the policy's fluent trinary value.
         """
         results: dict[URIRef, tuple[bool, str]] = {}
         obs_by_policy: dict[URIRef, list[ObservationStamped]] = {}
@@ -794,10 +800,7 @@ class ObservationManager:
 
         for policy_uri, policy_observations in obs_by_policy.items():
             if policy_uri in stale_policies:
-                results[policy_uri] = (
-                    False,
-                    "(observation) older than cached sample",
-                )
+                results[policy_uri] = (False, "(observation) older than cached sample")
                 continue
 
             for obs in policy_observations:
@@ -805,10 +808,23 @@ class ObservationManager:
 
             policy = self.obs_policies[policy_uri]
             if any(uri not in self.observation_cache for uri in policy.observation_uris):
+                # The policy has never had a complete cached snapshot.
                 results[policy_uri] = (True, "(observation) waiting for policy inputs")
                 continue
 
             samples = [self.observation_cache[uri] for uri in policy.observation_uris]
+            # Existing cache entries prove availability, not freshness. A complete
+            # evaluation requires every sample to lie within the current horizon.
+            if policy.horizon is not None:
+                reference_stamp = max(obs.stamp for obs in policy_observations)
+                samples = [
+                    sample for sample in samples if sample.stamp > reference_stamp - policy.horizon
+                ]
+                if len(samples) != len(policy.observation_uris):
+                    # Ignore batch in case of an incomplete snapshot.
+                    results[policy_uri] = (True, "(observation) waiting for fresh policy inputs")
+                    continue
+
             results[policy_uri] = policy.add_samples(samples)
         return results
 

--- a/src/bdd_dsl/models/observation.py
+++ b/src/bdd_dsl/models/observation.py
@@ -5,15 +5,18 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator
 from dataclasses import dataclass
 from inspect import isclass
+from math import dist, isclose
 from typing import Any, Protocol
 
-from rdf_utils.models.common import AttrLoaderProtocol, ModelBase
+from rdf_utils.models.common import AttrLoaderProtocol, ModelBase, get_node_types
+from rdf_utils.models.geom_coord import to_metres
 from rdf_utils.models.python import (
     URI_PY_TYPE_MODULE_ATTR,
     import_attr_from_model,
     load_py_module_attr,
 )
-from rdflib import Graph, URIRef
+from rdf_utils.models.vocab import URI_QUDT_PRED_UNIT, URI_QUDT_PRED_VALUE
+from rdflib import Graph, Literal, URIRef
 from scene_dsl.rdf_parser.scenex import SceneInstanceModel
 from trinary import Trinary, Unknown
 
@@ -22,9 +25,26 @@ from bdd_dsl.models.clauses import FluentClauseModel
 from bdd_dsl.models.time_constraint import get_duration, process_time_constraint_model
 from bdd_dsl.models.urirefs import (
     URI_BDD_PRED_OF_CLAUSE,
+    URI_CSTR_PRED_HAS_CONSTRAINT,
+    URI_CSTR_PRED_LOWER_THRESHOLD,
+    URI_CSTR_PRED_REFERENCE_VALUE,
+    URI_CSTR_PRED_THRESHOLD,
+    URI_CSTR_PRED_TOLERANCE,
+    URI_CSTR_PRED_UPPER_THRESHOLD,
+    URI_CSTR_TYPE_BILATERAL,
+    URI_CSTR_TYPE_EQUALITY,
+    URI_CSTR_TYPE_GREATER_THAN,
+    URI_CSTR_TYPE_LESS_THAN,
+    URI_GEOM_PRED_BETWEEN_ENTITIES,
+    URI_OBS_PRED_ENTITY_MAPPER,
+    URI_OBS_PRED_HAS_EVALUATOR,
     URI_OBS_PRED_HAS_OBSERVATION,
     URI_OBS_PRED_OBSERVES_TARGET,
     URI_OBS_PRED_PROVIDER,
+    URI_OBS_PRED_TIME_EXTRACTOR,
+    URI_OBS_TYPE_DIRECT_TRINARY_POLICY,
+    URI_OBS_TYPE_EVALUATED_POLICY,
+    URI_OBS_TYPE_LINEAR_DISTANCE_EVALUATOR,
     URI_OBS_TYPE_POLICY,
     URI_TIME_PRED_AFTER_EVT,
     URI_TIME_PRED_BEFORE_EVT,
@@ -92,6 +112,96 @@ class ObservationPolicyEvaluator(ABC):
     ) -> tuple[bool | Trinary, str]: ...
 
 
+def _distance_value(graph: Graph, constraint: URIRef, predicate: URIRef) -> float:
+    quantity = graph.value(constraint, predicate, any=False)
+    if not isinstance(quantity, URIRef):
+        raise TypeError(f"distance constraint {constraint} has invalid {predicate}: {quantity}")
+    val_node = graph.value(quantity, URI_QUDT_PRED_VALUE, any=False)
+    unit = graph.value(quantity, URI_QUDT_PRED_UNIT, any=False)
+    if not isinstance(val_node, Literal) or not isinstance(unit, URIRef):
+        raise TypeError(
+            f"distance quantity {quantity} requires a literal value and unit, found: value={val_node}, unit={unit}"
+        )
+    value = val_node.toPython()
+    if not isinstance(value, float):
+        raise TypeError(f"distance quantity {quantity} requires a float value, found: {value}")
+    return to_metres([float(value)], unit, quantity)[0]
+
+
+class LinearDistanceEvaluator(ObservationPolicyEvaluator):
+    constraint_id: URIRef
+    types: set[URIRef]
+    constraint_values: tuple[float, ...]
+
+    def __init__(self, graph: Graph, evaluator_id: URIRef, observations: set[URIRef]) -> None:
+        super().__init__()
+        between = set(graph.objects(evaluator_id, URI_GEOM_PRED_BETWEEN_ENTITIES))
+        if between != observations or len(between) != 2:
+            raise ValueError(
+                f"LinearDistanceEvaluator {evaluator_id} must reference exactly its two "
+                "policy observations"
+            )
+        cstr_id = graph.value(evaluator_id, URI_CSTR_PRED_HAS_CONSTRAINT, any=False)
+        if not isinstance(cstr_id, URIRef):
+            raise TypeError(f"LinearDistanceEvaluator {evaluator_id} has invalid constraint")
+        self.constraint_id = cstr_id
+        self.types = get_node_types(graph=graph, node_id=cstr_id)
+
+        if URI_CSTR_TYPE_LESS_THAN in self.types or URI_CSTR_TYPE_GREATER_THAN in self.types:
+            self.constraint_values = (
+                _distance_value(graph, self.constraint_id, URI_CSTR_PRED_THRESHOLD),
+            )
+        elif URI_CSTR_TYPE_BILATERAL in self.types:
+            self.constraint_values = (
+                _distance_value(graph, self.constraint_id, URI_CSTR_PRED_LOWER_THRESHOLD),
+                _distance_value(graph, self.constraint_id, URI_CSTR_PRED_UPPER_THRESHOLD),
+            )
+        elif URI_CSTR_TYPE_EQUALITY in self.types:
+            self.constraint_values = (
+                _distance_value(graph, self.constraint_id, URI_CSTR_PRED_REFERENCE_VALUE),
+                _distance_value(graph, self.constraint_id, URI_CSTR_PRED_TOLERANCE),
+            )
+        else:
+            raise ValueError(f"unsupported linear distance constraint types: {self.types}")
+
+    def _evaluate_samples(
+        self, observations: list[ObservationStamped]
+    ) -> tuple[bool | Trinary, str]:
+        if len(observations) != 2:
+            raise ValueError(f"expected two observations, got {len(observations)}")
+        try:
+            measured = dist(observations[0].value, observations[1].value)
+        except (TypeError, ValueError) as error:
+            raise TypeError("linear distance observations must be numeric sequences") from error
+
+        if URI_CSTR_TYPE_LESS_THAN in self.types:
+            result = measured < self.constraint_values[0] and not isclose(
+                measured, self.constraint_values[0]
+            )
+            expectation = f"less than {self.constraint_values[0]:g} m"
+        elif URI_CSTR_TYPE_GREATER_THAN in self.types:
+            result = measured > self.constraint_values[0] and not isclose(
+                measured, self.constraint_values[0]
+            )
+            expectation = f"greater than {self.constraint_values[0]:g} m"
+        elif URI_CSTR_TYPE_BILATERAL in self.types:
+            result = (
+                measured > self.constraint_values[0] or isclose(measured, self.constraint_values[0])
+            ) and (
+                measured < self.constraint_values[1] or isclose(measured, self.constraint_values[1])
+            )
+            expectation = f"between {self.constraint_values[0]:g} m and {self.constraint_values[1]:g} m inclusive"
+        else:
+            reference, tolerance = self.constraint_values
+            lower, upper = reference - tolerance, reference + tolerance
+            result = (measured > lower or isclose(measured, lower)) and (
+                measured < upper or isclose(measured, upper)
+            )
+            expectation = f"within {reference:g} m ± {tolerance:g} m ([{lower:g}, {upper:g}] m)"
+        comparison = "is" if result else "is not"
+        return result, f"linear distance {measured:g} m {comparison} {expectation}"
+
+
 @dataclass(frozen=True, slots=True)
 class TrinaryStamped:
     stamp: float
@@ -124,6 +234,24 @@ def trin_policy_and(trinaries: list[TrinaryStamped], **kwargs: Any) -> tuple[boo
     return result, reason
 
 
+def _uri_or_none_value(graph: Graph, subject_id: URIRef, predicate: URIRef) -> URIRef | None:
+    val_node = graph.value(subject=subject_id, predicate=predicate, any=False)
+    nm = graph.namespace_manager
+    if val_node is not None and not isinstance(val_node, URIRef):
+        raise TypeError(
+            f"'{subject_id.n3(nm)}' links to non-URI node via {predicate.n3(nm)}: {val_node}"
+        )
+    return val_node
+
+
+def _import_attr_from_graph(
+    graph: Graph, node_id: URIRef, types: set[URIRef] | None = None, quiet: bool = False
+) -> Any:
+    model = ModelBase(node_id=node_id, graph=graph, types=types)
+    load_py_module_attr(graph=graph, model=model, quiet=quiet)
+    return import_attr_from_model(model=model)
+
+
 class ObsPolicyModel(ModelBase):
     trinary_timeline: list[TrinaryStamped]
     observation_uris: set[URIRef]
@@ -140,6 +268,9 @@ class ObsPolicyModel(ModelBase):
     start_event: URIRef | None
     end_event: URIRef | None
     horizon: float | None
+    time_extractor_id: URIRef | None
+    entity_mapper_id: URIRef | None
+    evaluator_id: URIRef | None
 
     def __init__(
         self,
@@ -203,26 +334,64 @@ class ObsPolicyModel(ModelBase):
             provider_uri = graph.value(subject=obs_uri, predicate=URI_OBS_PRED_PROVIDER, any=False)
             if not isinstance(provider_uri, URIRef):
                 raise TypeError(f"Observation '{obs_uri}' has invalid provider: {provider_uri}")
-            target_uri = graph.value(obs_uri, URI_OBS_PRED_OBSERVES_TARGET, any=False)
-            if target_uri is not None and not isinstance(target_uri, URIRef):
-                raise TypeError(f"Observation '{obs_uri}' has invalid target: {target_uri}")
             self.observation_uris.add(obs_uri)
             self.observation_providers[obs_uri] = provider_uri
-            self.observation_targets[obs_uri] = target_uri
+            self.observation_targets[obs_uri] = _uri_or_none_value(
+                graph=graph, subject_id=obs_uri, predicate=URI_OBS_PRED_OBSERVES_TARGET
+            )
+
+        self.time_extractor_id = _uri_or_none_value(
+            graph=graph, subject_id=self.id, predicate=URI_OBS_PRED_TIME_EXTRACTOR
+        )
+        self.entity_mapper_id = _uri_or_none_value(
+            graph=graph, subject_id=self.id, predicate=URI_OBS_PRED_ENTITY_MAPPER
+        )
+        self.evaluator_id = _uri_or_none_value(
+            graph=graph, subject_id=self.id, predicate=URI_OBS_PRED_HAS_EVALUATOR
+        )
 
         self.evaluator = None
-        if URI_PY_TYPE_MODULE_ATTR in self.types:
-            load_py_module_attr(graph=graph, model=self, quiet=False)
-            evaluator = import_attr_from_model(model=self)
-            if isclass(evaluator):
-                # Stateful evaluator classes must have a no-argument constructor.
-                evaluator = evaluator()
-            if not isinstance(evaluator, ObservationPolicyEvaluator):
-                raise TypeError(
-                    f"ObservationPolicy '{self.id}' Python attribute must be an "
-                    "ObservationPolicyEvaluator class"
+        if URI_OBS_TYPE_DIRECT_TRINARY_POLICY in self.types:
+            if self.observation_uris or any(
+                (self.time_extractor_id, self.entity_mapper_id, self.evaluator_id)
+            ):
+                raise ValueError(
+                    f"TrinaryTopic policy '{self}' must not declare observations, adapters, or an evaluator"
                 )
-            self.evaluator = evaluator
+        elif URI_OBS_TYPE_EVALUATED_POLICY in self.types:
+            if (
+                not self.observation_uris
+                or self.time_extractor_id is None
+                or self.evaluator_id is None
+            ):
+                raise ValueError(
+                    f"Evaluated policy '{self}' requires observations, a time extractor, and an evaluator"
+                )
+
+            eval_types = get_node_types(graph=graph, node_id=self.evaluator_id)
+            if URI_OBS_TYPE_LINEAR_DISTANCE_EVALUATOR in eval_types:
+                self.evaluator = LinearDistanceEvaluator(
+                    graph, self.evaluator_id, self.observation_uris
+                )
+            elif URI_PY_TYPE_MODULE_ATTR in eval_types:
+                evaluator = _import_attr_from_graph(
+                    graph=graph, node_id=self.evaluator_id, types=eval_types
+                )
+                if isclass(evaluator):
+                    evaluator = evaluator()
+                if not isinstance(evaluator, ObservationPolicyEvaluator):
+                    raise TypeError(
+                        f"ObservationPolicy '{self}' Python evaluator must be an ObservationPolicyEvaluator class"
+                    )
+                self.evaluator = evaluator
+            else:
+                raise TypeError(
+                    f"ObservationPolicy '{self}' has unsupported evaluator types: {eval_types}"
+                )
+        else:
+            raise ValueError(
+                f"ObservationPolicy '{self}' has unsupported policy types: {self.types}"
+            )
 
         self.start_time = None
         self.end_time = None
@@ -390,9 +559,9 @@ class ObsPolicyModel(ModelBase):
 class ObservationManager:
     """Route provider values into policy-local caches and fluent timelines.
 
-    Register provider adapters after building a scenario context. Feed raw provider
-    messages through :meth:`update_provider_observation`; it extracts a timestamp,
-    maps target-specific values, and evaluates each complete policy snapshot once.
+    Provider adapters are loaded from policy RDF when building a scenario context. Feed
+    raw provider messages through :meth:`update_provider_observation`; it extracts a
+    timestamp, maps target-specific values, and evaluates each complete policy snapshot once.
     :meth:`update_fpolicy_assertion` remains the compatibility ingress for direct
     ``TrinaryStamped`` topic policies.
     """
@@ -489,14 +658,28 @@ class ObservationManager:
             self._register_fluent_event(evt_uri=obs_pol.end_event, fc_id=fc.id)
             self.obs_policies[obs_pol.id] = obs_pol
 
-    def register_provider(
-        self,
-        provider_uri: URIRef,
-        timestamp_extractor: TimestampedObservationProtocol | None = None,
-        entity_mapper: EntityObservationMapperProtocol | None = None,
-    ) -> None:
-        """Register optional timestamp and entity-mapping adapters for a provider."""
-        self._provider_registry[provider_uri] = (timestamp_extractor, entity_mapper)
+    def load_provider_adapters(self, graph: Graph) -> None:
+        """Load policy-declared provider adapters from RDF."""
+        declarations = {}
+        for policy in self.obs_policies.values():
+            declaration = (policy.time_extractor_id, policy.entity_mapper_id)
+            for provider_uri in policy.observation_providers.values():
+                previous = declarations.setdefault(provider_uri, declaration)
+                if previous != declaration:
+                    raise ValueError(
+                        f"conflicting adapters declared for observation provider '{provider_uri}'"
+                    )
+
+        for provider_uri, (time_extractor_id, entity_mapper_id) in declarations.items():
+            time_extractor = None
+            if time_extractor_id is not None:
+                time_extractor = _import_attr_from_graph(graph=graph, node_id=time_extractor_id)
+
+            entity_mapper = None
+            if entity_mapper_id is not None:
+                entity_mapper = _import_attr_from_graph(graph=graph, node_id=entity_mapper_id)
+
+            self._provider_registry[provider_uri] = (time_extractor, entity_mapper)
 
     def bind_observation_targets(self, bindings: dict[URIRef, Any]) -> None:
         """Resolve template-variable targets for this scenario context."""
@@ -506,6 +689,10 @@ class ObservationManager:
                     continue
                 bound_target = bindings.get(target_uri)
                 if bound_target is not None:
+                    if policy.entity_mapper_id is None:
+                        raise ValueError(
+                            f"variable observation target '{target_uri}' requires an entity mapper"
+                        )
                     if not isinstance(bound_target, URIRef):
                         raise TypeError(
                             f"observation target '{target_uri}' is bound to non-URI {bound_target}"
@@ -667,4 +854,5 @@ class ObservationManager:
                 fc=fc,
                 obs_loaders=obs_loaders,
             )
+        obs_manager.load_provider_adapters(graph)
         return obs_manager

--- a/src/bdd_dsl/models/urirefs.py
+++ b/src/bdd_dsl/models/urirefs.py
@@ -1,9 +1,16 @@
 # SPDX-License-Identifier:  GPL-3.0-or-later
-from rdf_utils.namespace import NS_MM_TIME
+from rdf_utils.namespace import (
+    NS_MM_GEOM_COORD,
+    NS_MM_GEOM_REL,
+    NS_MM_QUDT_QTY,
+    NS_MM_TIME,
+)
 
 from bdd_dsl.models.namespace import (
     NS_MM_BDD,
     NS_MM_BHV,
+    NS_MM_CSTR,
+    NS_MM_CSTR_EXT,
     NS_MM_OBS,
     NS_MM_ROS,
     NS_MM_TASK,
@@ -40,6 +47,32 @@ URI_OBS_PRED_POLICY = NS_MM_OBS["has-policy"]
 URI_OBS_PRED_PROVIDER = NS_MM_OBS["has-provider"]
 URI_OBS_PRED_HAS_OBSERVATION = NS_MM_OBS["has-observation"]
 URI_OBS_PRED_OBSERVES_TARGET = NS_MM_OBS["observes-target"]
+URI_OBS_PRED_TIME_EXTRACTOR = NS_MM_OBS["time-extractor"]
+URI_OBS_PRED_ENTITY_MAPPER = NS_MM_OBS["entity-mapper"]
+URI_OBS_PRED_HAS_EVALUATOR = NS_MM_OBS["has-evaluator"]
+URI_OBS_TYPE_DIRECT_TRINARY_POLICY = NS_MM_OBS["DirectTrinaryPolicy"]
+URI_OBS_TYPE_EVALUATED_POLICY = NS_MM_OBS["EvaluatedObservationPolicy"]
+URI_OBS_TYPE_LINEAR_DISTANCE_EVALUATOR = NS_MM_OBS["LinearDistanceEvaluator"]
+
+# Linear distance
+URI_GEOM_TYPE_LINEAR_DISTANCE = NS_MM_GEOM_REL["LinearDistance"]
+URI_GEOM_PRED_BETWEEN_ENTITIES = NS_MM_GEOM_REL["between-entities"]
+URI_GEOM_TYPE_LINEAR_DISTANCE_COORD = NS_MM_GEOM_COORD["LinearDistanceCoordinate"]
+URI_GEOM_TYPE_DISTANCE_REF = NS_MM_GEOM_COORD["DistanceReference"]
+URI_GEOM_PRED_COORD_OF = NS_MM_GEOM_COORD["of"]
+URI_QUDT_QK_DISTANCE = NS_MM_QUDT_QTY["Distance"]
+URI_CSTR_TYPE_LINEAR_DISTANCE = NS_MM_CSTR["LinearDistanceConstraint"]
+URI_CSTR_TYPE_LESS_THAN = NS_MM_CSTR["LessThanConstraint"]
+URI_CSTR_TYPE_GREATER_THAN = NS_MM_CSTR["GreaterThanConstraint"]
+URI_CSTR_TYPE_BILATERAL = NS_MM_CSTR["BilateralConstraint"]
+URI_CSTR_TYPE_EQUALITY = NS_MM_CSTR["EqualityConstraint"]
+URI_CSTR_PRED_HAS_CONSTRAINT = NS_MM_CSTR_EXT["has-constraint"]
+URI_CSTR_PRED_QUANTITY = NS_MM_CSTR["quantity"]
+URI_CSTR_PRED_THRESHOLD = NS_MM_CSTR["threshold"]
+URI_CSTR_PRED_LOWER_THRESHOLD = NS_MM_CSTR["lower-threshold"]
+URI_CSTR_PRED_UPPER_THRESHOLD = NS_MM_CSTR["upper-threshold"]
+URI_CSTR_PRED_REFERENCE_VALUE = NS_MM_CSTR["reference-value"]
+URI_CSTR_PRED_TOLERANCE = NS_MM_CSTR_EXT["tolerance"]
 
 # ROS
 URI_ROS_TYPE_TOPIC = NS_MM_ROS["Topic"]

--- a/src/bdd_dsl/models/user_story.py
+++ b/src/bdd_dsl/models/user_story.py
@@ -51,6 +51,7 @@ BDD_SHACL_URLS = {
     f"{URL_SECORO_MM}/acceptance-criteria/bdd/environment.shacl.ttl": "turtle",
     f"{URL_SECORO_MM}/acceptance-criteria/bdd/agent.shacl.ttl": "turtle",
     f"{URL_SECORO_MM}/acceptance-criteria/bdd/execution-context.shacl.ttl": "turtle",
+    f"{URL_SECORO_MM}/acceptance-criteria/bdd/observation.shacl.ttl": "turtle",
     URL_MM_PYTHON_SHACL: "turtle",
 }
 Q_US_VAR = f"""

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -15,6 +15,7 @@ from rdf_utils.models.vocab import URI_EXEC_PRED_RUNS_SCENE, URI_EXEC_TYPE_SCENE
 from rdf_utils.namespace import URL_MM_PYTHON_SHACL, URL_SECORO_M
 from rdf_utils.resolver import install_resolver
 from rdflib import RDF, Dataset, Graph, Literal, URIRef
+from trinary import Unknown
 
 from bdd_dsl.execution.common import URL_MM_EXEC_SHACL
 from bdd_dsl.execution.scenario import ScenarioExecutionModel
@@ -109,16 +110,56 @@ def test_policy_result_uses_default_until_an_accepted_sample_exists():
 
     class Evaluator(ObservationPolicyEvaluator):
         def _evaluate_samples(self, observations):
-            return False, "collision recorded"
+            return observations[0].value, "observation value"
 
     policy.evaluator = Evaluator((True, "no collision recorded"))
     assert policy.get_result(1.0, trin_policy_and).trinary is True
 
-    accepted, _ = policy.add_samples([ObservationStamped(observation_uri, provider_uri, 2.0, True)])
+    accepted, _ = policy.add_samples(
+        [ObservationStamped(observation_uri, provider_uri, 2.0, False)]
+    )
     assert accepted
     result = policy.get_result(2.0, trin_policy_and)
     assert result.trinary is False
     assert result.reason == "at least one assertion is false"
+
+    result = policy.get_result(12.0, trin_policy_and)
+    assert result.trinary is True
+    assert result.reason == "no collision recorded"
+
+
+def test_before_policy_closes_on_the_final_event_relative_window():
+    policy_uri = URIRef("urn:test:policy-close")
+    observation_uri = URIRef("urn:test:obs-close")
+    provider_uri = URIRef("urn:test:provider-close")
+    end_uri = URIRef("urn:test:end-close")
+    graph = Graph()
+    graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
+    graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
+    graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
+    graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
+    add_python_role(graph, policy_uri, URI_OBS_PRED_HAS_EVALUATOR, "evaluator")
+    add_before_policy_time(graph, policy_uri, end_uri)
+    policy = ObsPolicyModel(
+        node_id=policy_uri,
+        graph=graph,
+        fluent_id=URIRef("urn:test:fluent-close"),
+        fluent_types={URI_TIME_TYPE_BEFORE_EVT},
+    )
+
+    class Evaluator(ObservationPolicyEvaluator):
+        def _evaluate_samples(self, observations):
+            return observations[0].value, "observation value"
+
+    policy.evaluator = Evaluator()
+    assert policy.add_samples([ObservationStamped(observation_uri, provider_uri, 9.0, False)])[0]
+    assert policy.add_samples([ObservationStamped(observation_uri, provider_uri, 14.0, True)])[0]
+    assert policy.get_result(14.0, trin_policy_and).trinary is False
+
+    policy.on_event(end_uri, 20.0)
+
+    result = policy.get_result(100.0, trin_policy_and)
+    assert result.trinary is True
 
 
 EXEC_MODEL_URLS = {
@@ -380,6 +421,13 @@ class BDDExecTest(unittest.TestCase):
         self.assertTrue(all(policy.observation_targets[uri] is None for uri in observation_uris))
 
         results = manager.update_observations(
+            [ObservationStamped(observation_uris[0], provider_uri, 1.0, True)]
+        )
+        self.assertTrue(results[policy_uri][0])
+        self.assertEqual(calls, [])
+        self.assertIs(policy.get_result(1.0, trin_policy_and).trinary, Unknown)
+
+        results = manager.update_observations(
             [
                 ObservationStamped(observation_uri, provider_uri, stamp, True)
                 for observation_uri, stamp in zip(observation_uris, (1.0, 2.0), strict=True)
@@ -405,6 +453,22 @@ class BDDExecTest(unittest.TestCase):
         self.assertEqual(manager.observation_cache, cached_snapshot)
         self.assertEqual(len(calls), 1)
         self.assertEqual(len(policy.trinary_timeline), 1)
+
+        results = manager.update_observations(
+            [ObservationStamped(observation_uris[0], provider_uri, 13.0, False)]
+        )
+
+        self.assertTrue(results[policy_uri][0])
+        self.assertEqual(len(calls), 1)
+        self.assertIs(policy.get_result(13.0, trin_policy_and).trinary, Unknown)
+
+        results = manager.update_observations(
+            [ObservationStamped(observation_uris[1], provider_uri, 14.0, True)]
+        )
+
+        self.assertTrue(results[policy_uri][0])
+        self.assertEqual(len(calls), 2)
+        self.assertIs(policy.get_result(14.0, trin_policy_and).trinary, True)
 
     def test_python_observation_policy_instantiates_callable_class_once(self):
         class StatefulEvaluator(ObservationPolicyEvaluator):

--- a/tests/test_bdd_exec.py
+++ b/tests/test_bdd_exec.py
@@ -36,10 +36,14 @@ from bdd_dsl.models.urirefs import (
     URI_BDD_TYPE_SCENARIO_EXEC,
     URI_BHV_PRED_OF_BHV,
     URI_BHV_TYPE_BHV,
+    URI_OBS_PRED_ENTITY_MAPPER,
+    URI_OBS_PRED_HAS_EVALUATOR,
     URI_OBS_PRED_HAS_OBSERVATION,
     URI_OBS_PRED_OBSERVES_TARGET,
     URI_OBS_PRED_POLICY,
     URI_OBS_PRED_PROVIDER,
+    URI_OBS_PRED_TIME_EXTRACTOR,
+    URI_OBS_TYPE_EVALUATED_POLICY,
     URI_OBS_TYPE_OBSERVATION,
     URI_OBS_TYPE_POLICY,
     URI_TIME_PRED_AFTER_EVT,
@@ -87,8 +91,14 @@ def test_default_observation_evaluator_handles_empty_and_non_empty_samples():
 
 def test_policy_result_uses_default_until_an_accepted_sample_exists():
     policy_uri = URIRef("urn:test:policy-default")
+    observation_uri = URIRef("urn:test:obs")
+    provider_uri = URIRef("urn:test:provider")
     graph = Graph()
     graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
+    graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
+    graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
+    graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
+    add_python_role(graph, policy_uri, URI_OBS_PRED_HAS_EVALUATOR, "evaluator")
     add_before_policy_time(graph, policy_uri, URIRef("urn:test:end-default"))
     policy = ObsPolicyModel(
         node_id=policy_uri,
@@ -104,9 +114,7 @@ def test_policy_result_uses_default_until_an_accepted_sample_exists():
     policy.evaluator = Evaluator((True, "no collision recorded"))
     assert policy.get_result(1.0, trin_policy_and).trinary is True
 
-    accepted, _ = policy.add_samples(
-        [ObservationStamped(URIRef("urn:test:obs"), URIRef("urn:test:provider"), 2.0, True)]
-    )
+    accepted, _ = policy.add_samples([ObservationStamped(observation_uri, provider_uri, 2.0, True)])
     assert accepted
     result = policy.get_result(2.0, trin_policy_and)
     assert result.trinary is False
@@ -172,6 +180,37 @@ def add_before_policy_time(graph, policy_uri, end_uri):
     graph.add((policy_uri, URI_TIME_PRED_HRZN_SEC, Literal(10.0)))
 
 
+class FixtureEvaluator(ObservationPolicyEvaluator):
+    def _evaluate_samples(self, observations):
+        return bool(observations), "fixture"
+
+
+def fixture_timestamp(_, receipt_stamp):
+    return receipt_stamp + 1
+
+
+def fixture_entity_mapper(observation, _, targets):
+    return [EntityObservation(targets[0], observation)]
+
+
+def add_python_role(graph, policy_uri, predicate, name, attr_name="FixtureEvaluator"):
+    role_uri = URIRef(f"{policy_uri}/{name}")
+    if predicate == URI_OBS_PRED_HAS_EVALUATOR:
+        graph.add((policy_uri, RDF.type, URI_OBS_TYPE_EVALUATED_POLICY))
+        add_python_role(
+            graph,
+            policy_uri,
+            URI_OBS_PRED_TIME_EXTRACTOR,
+            "time-extractor",
+            "fixture_timestamp",
+        )
+    graph.add((policy_uri, predicate, role_uri))
+    graph.add((role_uri, RDF.type, URI_PY_TYPE_MODULE_ATTR))
+    graph.add((role_uri, URI_PY_PRED_MODULE_NAME, Literal("test_bdd_exec")))
+    graph.add((role_uri, URI_PY_PRED_ATTR_NAME, Literal(attr_name)))
+    return role_uri
+
+
 class BDDExecTest(unittest.TestCase):
     def setUp(self):
         install_resolver()
@@ -215,6 +254,14 @@ class BDDExecTest(unittest.TestCase):
         graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
         graph.add((observation_uri, URI_OBS_PRED_OBSERVES_TARGET, target_uri))
         graph.add((provider_uri, RDF.type, URIRef("urn:test:provider-type")))
+        add_python_role(graph, policy_uri, URI_OBS_PRED_HAS_EVALUATOR, "evaluator")
+        add_python_role(
+            graph,
+            policy_uri,
+            URI_OBS_PRED_ENTITY_MAPPER,
+            "entity-mapper",
+            "fixture_entity_mapper",
+        )
         fluent_id = URIRef("urn:test:fluent")
         graph.add((policy_uri, URI_BDD_PRED_OF_CLAUSE, fluent_id))
         add_before_policy_time(graph, policy_uri, URIRef("urn:test:end"))
@@ -251,11 +298,10 @@ class BDDExecTest(unittest.TestCase):
             manager.observation_targets_for_provider(provider_uri),
             {observation_uri: bound_target_uri},
         )
-        manager.register_provider(
-            provider_uri,
-            timestamp_extractor=lambda _, receipt_stamp: receipt_stamp + 1,
-            entity_mapper=lambda _, __, ___: [EntityObservation(bound_target_uri, True)],
-        )
+        self.assertEqual(manager.update_provider_observation(provider_uri, object(), 1.0), {})
+        self.assertNotIn(observation_uri, manager.observation_cache)
+
+        manager.load_provider_adapters(graph)
         results = manager.update_provider_observation(provider_uri, object(), 1.0)
         self.assertEqual(results, {policy_uri: (True, "")})
         self.assertEqual(policy.trinary_timeline[0].stamp, 2.0)
@@ -278,6 +324,26 @@ class BDDExecTest(unittest.TestCase):
                 ]
             )
 
+    def test_shared_provider_rejects_conflicting_adapters(self):
+        provider_uri = URIRef("urn:test:provider")
+        manager = ObservationManager(scr_exec=SimpleNamespace())
+        manager.providers[provider_uri] = SimpleNamespace()
+        manager.obs_policies = {
+            URIRef("urn:test:first-policy"): SimpleNamespace(
+                observation_providers={URIRef("urn:test:first-observation"): provider_uri},
+                time_extractor_id=URIRef("urn:test:first-extractor"),
+                entity_mapper_id=None,
+            ),
+            URIRef("urn:test:second-policy"): SimpleNamespace(
+                observation_providers={URIRef("urn:test:second-observation"): provider_uri},
+                time_extractor_id=URIRef("urn:test:second-extractor"),
+                entity_mapper_id=None,
+            ),
+        }
+
+        with self.assertRaisesRegex(ValueError, "conflicting adapters"):
+            manager.load_provider_adapters(Graph())
+
     def test_observation_batch_evaluates_policy_once_after_caching_all_samples(self):
         graph = Graph()
         policy_uri = URIRef("urn:test:policy")
@@ -288,6 +354,7 @@ class BDDExecTest(unittest.TestCase):
             graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
             graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
             graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))
+        add_python_role(graph, policy_uri, URI_OBS_PRED_HAS_EVALUATOR, "evaluator")
         add_before_policy_time(graph, policy_uri, URIRef("urn:test:end"))
 
         policy = ObsPolicyModel(
@@ -354,9 +421,7 @@ class BDDExecTest(unittest.TestCase):
         observation_uri = URIRef("urn:test:observation")
         provider_uri = URIRef("urn:test:provider")
         graph.add((policy_uri, RDF.type, URI_OBS_TYPE_POLICY))
-        graph.add((policy_uri, RDF.type, URI_PY_TYPE_MODULE_ATTR))
-        graph.add((policy_uri, URI_PY_PRED_MODULE_NAME, Literal("operator")))
-        graph.add((policy_uri, URI_PY_PRED_ATTR_NAME, Literal("truth")))
+        add_python_role(graph, policy_uri, URI_OBS_PRED_HAS_EVALUATOR, "evaluator")
         graph.add((policy_uri, URI_OBS_PRED_HAS_OBSERVATION, observation_uri))
         graph.add((observation_uri, RDF.type, URI_OBS_TYPE_OBSERVATION))
         graph.add((observation_uri, URI_OBS_PRED_PROVIDER, provider_uri))


### PR DESCRIPTION
## Summary

Update observation-policy loading and evaluation to support explicit direct-trinary and evaluated policy types, policy-owned provider adapters, and built-in linear-distance evaluation.

This also fixes horizon handling so stale observations cannot keep a before-event fluent true or false indefinitely, while incomplete snapshots do not poison later complete results with a stored `Unknown`.

## Changes

- Parse and validate `DirectTrinaryPolicy` and `EvaluatedObservationPolicy` RDF types.
- Load time extractors, entity mappers, and Python evaluators through policy RDF links.
- Replace manual provider registration with policy-driven adapter loading.
- Detect conflicting adapter declarations for shared providers.
- Require entity mappers for variable observation targets.
- Add `LinearDistanceEvaluator` with:
  - exactly two policy observations;
  - QUDT unit conversion;
  - less-than, greater-than, bilateral, and equality constraints;
  - detailed evaluation reasons.
- Add observation, evaluator, geometry, and constraint URI constants.
- Include the observation SHACL model in user-story validation.
- Prune open before-event timelines relative to result time.
- Preserve the final event-relative window after a before-event policy closes.
- Exclude expired cached samples from complete policy snapshots.
- Defer incomplete snapshots without recording sticky default assertions.
- Document `update_observations()` as mapping policy URIs to `(accepted, reason)` outcomes.

## Compatibility

Consumers must use the new typed policy RDF structure and policy-level adapter declarations. The previous imperative `register_provider()` API is replaced by `load_provider_adapters()`.

This change is intended to land with the corresponding metamodel, RobBDD, and `bdd_exec_ros2` updates.

## Related

- RDF concepts & SHACL rules added in: minhnh/metamodels-bdd#11
- SHACL published in secorolab/metamodels#61