### PR TITLE
refactor: remove shared ROS and QUDT vocabulary definitions

### DIFF
--- a/src/bdd_dsl/models/namespace.py
+++ b/src/bdd_dsl/models/namespace.py
@@ -4,7 +4,6 @@ from rdflib import Graph, Namespace
 from bdd_dsl.models.uri import (
     URI_MM_BDD,
     URI_MM_BHV,
-    URI_MM_ROS,
     URI_MM_SIM,
     URI_MM_TASK,
 )
@@ -14,7 +13,6 @@ NS_MM_BDD = Namespace(URI_MM_BDD)
 NS_MM_BHV = Namespace(URI_MM_BHV)
 NS_MM_TASK = Namespace(URI_MM_TASK)
 NS_MM_SIM = Namespace(URI_MM_SIM)
-NS_MM_ROS = Namespace(URI_MM_ROS)
 NS_MM_CSTR = Namespace("https://comp-rob2b.github.io/metamodels/task/constraint#")
 NS_MM_CSTR_EXT = Namespace("https://secorolab.github.io/metamodels/task/constraint#")
 

--- a/src/bdd_dsl/models/uri.py
+++ b/src/bdd_dsl/models/uri.py
@@ -13,8 +13,6 @@ URI_MM_BDD = f"{URL_SECORO_MM}/acceptance-criteria/bdd#"
 URI_MM_EVENT = f"{URL_SESAME}/metamodels/coordination/event#"
 URI_MM_BT = f"{URL_SESAME}/metamodels/coordination/behaviour-tree#"
 URI_MM_PY = f"{URL_SESAME}/metamodels/languages/python#"
-URI_MM_ROS = "https://index.ros.org/p/"
-
 URI_M_CRDN = f"{URL_SESAME}/models/coordination/"
 
 # URL to SHACL constraints

--- a/src/bdd_dsl/models/urirefs.py
+++ b/src/bdd_dsl/models/urirefs.py
@@ -2,7 +2,6 @@
 from rdf_utils.namespace import (
     NS_MM_GEOM_COORD,
     NS_MM_GEOM_REL,
-    NS_MM_QUDT_QTY,
 )
 
 from bdd_dsl.models.namespace import (
@@ -10,7 +9,6 @@ from bdd_dsl.models.namespace import (
     NS_MM_BHV,
     NS_MM_CSTR,
     NS_MM_CSTR_EXT,
-    NS_MM_ROS,
     NS_MM_TASK,
 )
 
@@ -33,7 +31,6 @@ URI_GEOM_PRED_BETWEEN_ENTITIES = NS_MM_GEOM_REL["between-entities"]
 URI_GEOM_TYPE_LINEAR_DISTANCE_COORD = NS_MM_GEOM_COORD["LinearDistanceCoordinate"]
 URI_GEOM_TYPE_DISTANCE_REF = NS_MM_GEOM_COORD["DistanceReference"]
 URI_GEOM_PRED_COORD_OF = NS_MM_GEOM_COORD["of"]
-URI_QUDT_QK_DISTANCE = NS_MM_QUDT_QTY["Distance"]
 URI_CSTR_TYPE_LINEAR_DISTANCE = NS_MM_CSTR["LinearDistanceConstraint"]
 URI_CSTR_TYPE_LESS_THAN = NS_MM_CSTR["LessThanConstraint"]
 URI_CSTR_TYPE_GREATER_THAN = NS_MM_CSTR["GreaterThanConstraint"]
@@ -46,14 +43,6 @@ URI_CSTR_PRED_LOWER_THRESHOLD = NS_MM_CSTR["lower-threshold"]
 URI_CSTR_PRED_UPPER_THRESHOLD = NS_MM_CSTR["upper-threshold"]
 URI_CSTR_PRED_REFERENCE_VALUE = NS_MM_CSTR["reference-value"]
 URI_CSTR_PRED_TOLERANCE = NS_MM_CSTR_EXT["tolerance"]
-
-# ROS
-URI_ROS_TYPE_TOPIC = NS_MM_ROS["Topic"]
-URI_ROS_TYPE_SERVICE = NS_MM_ROS["Service"]
-URI_ROS_TYPE_ACTION = NS_MM_ROS["Action"]
-URI_ROS_TYPE_SIM_ENTITY_STATE_PROVIDER = NS_MM_ROS["SimulationEntityStateProvider"]
-URI_ROS_PRED_CHNL_NAME = NS_MM_ROS["channel-name"]
-URI_ROS_PRED_TYPE_NAME = NS_MM_ROS["type-name"]
 
 # BDD
 URI_BDD_TYPE_US = NS_MM_BDD["UserStory"]


### PR DESCRIPTION
Move ownership of common vocabulary terms to rdf-utils, matching minhnh/rdf-utils#34